### PR TITLE
docs: migrate docs from https://prismic.io/docs to Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,11 +6,11 @@ This is a blank [Laravel](https://laravel.com) project that will connect to any 
 
 ### Launch the starter project
 
-*(Assuming you've [installed Laravel](https://laravel.com/docs/5.5/installation))*
+_(Assuming you've [installed Laravel](https://laravel.com/docs/5.5/installation))_
 
 Fork this repository, then clone your fork, and run this in your newly created directory:
 
-``` bash
+```bash
 composer install
 ```
 
@@ -28,7 +28,7 @@ Then start your server:
 php artisan serve
 ```
 
-Your Laravel starter project is now up and running! 
+Your Laravel starter project is now up and running!
 
 ### Configure the starter project
 
@@ -44,9 +44,9 @@ You may have to restart your server.
 
 When the project is first launched and viewed, it will by default display a help page. Here you will find some documentation to help you get started with your Laravel project.
 
-It includes an example that shows how to create a route and query a document of the custom type "page". It then shows how to integrate the content into the Laravel templates. 
+It includes an example that shows how to create a route and query a document of the custom type "page". It then shows how to integrate the content into the Laravel templates.
 
-Check it out to get a better understanding of how you would create your own routes and templates for your project. You can also explore our documentation to learn more about how to [query the API](https://prismic.io/docs/php/query-the-api/how-to-query-the-api) and how to integrate content fields like [Rich Text](https://prismic.io/docs/php/templating/rich-text), [Images](https://prismic.io/docs/php/templating/image), and more.
+Check it out to get a better understanding of how you would create your own routes and templates for your project. You can also explore our documentation to learn more about how to [query the API](./docs/02-query-the-api/01-how-to-query-the-api.md) and how to integrate content fields like [Rich Text](./docs/03-templating/14-rich-text-and-title.md), [Images](./docs/03-templating/09-images.md), and more.
 
 ## Deploying your Laravel application
 
@@ -94,7 +94,7 @@ You can read more about launching your project with Heroku here in their [Larave
 
 ## Learn more about prismic.io
 
-If you are looking for more resources to learn more about prismic.io, you can find out [how to get started with prismic.io](https://prismic.io/quickstart#?lang=php) and learn more by exploring [our full documentation](https://prismic.io/docs/php/getting-started/with-the-php-starter-kit).
+If you are looking for more resources to learn more about prismic.io, you can find out [how to get started with prismic.io](https://prismic.io/docs) and learn more by exploring [our full documentation](./docs).
 
 ### Understand the PHP development kit
 

--- a/docs/01-getting-started/01-starting-from-scratch.md
+++ b/docs/01-getting-started/01-starting-from-scratch.md
@@ -1,0 +1,76 @@
+# Getting started
+
+Prismic makes it easy to get started on a new Laravel project by providing a specific Laravel starter project.
+
+## Create a content repository
+
+A content repository is where you can define, edit, and publish your website content.
+
+[**Create a new repository**](https://prismic.io/dashboard/new-repository/)
+
+## Download the Laravel Starter
+
+The starter kit allows you to query and retrieve content from your Prismic content repository and integrate it into your website templates. It's the easiest way to get started with a new project.
+
+[**Download the Starter**](https://github.com/prismicio/php-laravel-starter/archive/master.zip)
+
+Unzip the downloaded project files into the desired location for your new project.
+
+## Configure your project
+
+Replace the repository URL in your Prismic configuration file (located at config/prismic.php) with your repository’s API endpoint:
+
+```
+// In config/prismic.php
+'url' => 'https://your-repo-name.cdn.prismic.io/api/v2',
+```
+
+Fire up a terminal (command prompt or similar on Windows), point it to your project location and run the following commands!
+
+> Note that you will need to make sure to first have [Composer](https://getcomposer.org/) installed before running this command. Check out the [Composer Getting Started](https://getcomposer.org/doc/00-intro.md) page for installation instructions. You may also need to update the version of PHP on your computer to get the project working correctly.
+
+First you'll need to install the dependencies for the project. Run the following command:
+
+```bash
+composer install
+```
+
+Next you need to make a copy of the .env.example file and rename it to .env inside your Laravel project root:
+
+```bash
+cp .env.example .env
+```
+
+Then run the following command to generate your app key:
+
+```bash
+php artisan key:generate
+```
+
+Now you can launch your local server:
+
+```bash
+php artisan serve
+```
+
+You can now open your browser to [http://localhost:8000](http://localhost:8000), where you will find a tutorial page. This page contains information helpful to getting started. You will learn how to query the API and start building pages for your new site.
+
+> **Pagination of API Results**
+>
+> When querying a Prismic repository, your results will be paginated. By default, there are 20 documents per page in the results. You can read more about how to manipulate the pagination in the [Pagination for Results](../02-query-the-api/18-pagination-for-results.md) page.
+
+## And your Prismic journey begins!
+
+Now you're all set to start building your new website with the Prismic content management system. Here are the next steps you need to take.
+
+### Define your Custom Types
+
+First you will need to model your pages, blog posts, articles, etc. into different Custom Types. Refer to our documentation to learn more about [constructing your Custom Types](https://user-guides.prismic.io/content-modeling-and-custom-types/structure-your-content/introduction-to-custom-type-building) using our easy drag and drop builder.
+
+### Query your documents
+
+After you have created and published some documents in your content repository, you will be able to query your API and retrieve the content. We provide explanations and plenty of examples of queries in the documentation. Start by learning more on the [How to Query the API](../02-query-the-api/01-how-to-query-the-api.md) page.
+
+### Integrate content into your templates
+
+The final step will be to integrate your content into the website templates. Check out the [templating documentation](../03-templating/01-the-response-object.md) to learn how to integrate each content field type.

--- a/docs/01-getting-started/02-integrating-with-existing-project.md
+++ b/docs/01-getting-started/02-integrating-with-existing-project.md
@@ -1,0 +1,90 @@
+# Integrating with an existing project
+
+If you already have an existing Laravel project that you want to integrate with Prismic, then you simply need to add the PHP Prismic development kit library as a dependency. Here we will show you all the steps needed to get Prismic integrated into your site.
+
+## 1. Create a content repository
+
+A content repository is where you can define, edit, and publish your website content.
+
+[**Create a new repository**](https://prismic.io/dashboard/new-repository/)
+
+Next you will need to model your content, create your custom types, and publish some documents to your content repository.
+
+Now, let’s take a look at how to retrieve and integrate this new content with your project.
+
+## 2. Add the PHP kit as a dependency
+
+Now let’s add the Prismic PHP kit as a dependency to your project. Launch the terminal (command prompt or similar on Windows), and point it to your project location.
+
+> Note that you will need to make sure to first have [Composer](https://getcomposer.org/) installed before running this command. Check out the [Composer Getting Started](https://getcomposer.org/doc/00-intro.md) page for installation instructions.
+
+Run the following command:
+
+```bash
+composer require prismic/php-sdk
+```
+
+## 3. Include the dependency
+
+To use the Prismic PHP library, you will need to include an instance of it. Simply add the following code:
+
+```
+<?php
+include_once __DIR__.'/vendor/autoload.php';
+
+use Prismic\Api;
+use Prismic\LinkResolver;
+use Prismic\Predicates;
+```
+
+## 4. Get the API and query your content
+
+Now we can query your Prismic repository and retrieve the content as shown below:
+
+```
+<?php
+$api = Api::get("https://your-repo-name.cdn.prismic.io/api/v2");
+$response = $api->query(Predicates::at('document.type', 'page'));
+```
+
+If you are using a private repository, then you’ll need to [generate an access token](https://intercom.help/prismicio/api-application-and-token-management/generating-an-access-token) and then include it like this:
+
+```
+<?php
+$url = "https://your-repo-name.cdn.prismic.io/api/v2";
+$token = "MC5XUkgtxelvOGEBdVViSEla.E--_xe-_qe-vUXvv7...1r77-9FgXv";
+$api = Api::get($url, $token);
+$response = $api->query(Predicates::at('document.type', 'page'));
+```
+
+To learn more about querying the API, check out the [How to Query the API](../02-query-the-api/01-how-to-query-the-api.md) page.
+
+### Pagination of API Results
+
+When querying a Prismic repository, your results will be paginated. By default, there are 20 documents per page in the results. You can read more about how to manipulate the pagination in the [Pagination for Results](../02-query-the-api/18-pagination-for-results.md) page.
+
+## 5. Add the content to your templates
+
+Once you have retrieved your content, you can include the content in your template using the helper functions in the PHP development kit. Here is a simple example:
+
+```
+<?php
+use Prismic\Dom\RichText;
+
+$document = $response->results[0];
+?>
+
+<section>
+    <h1>{{ RichText::asText($document->data->title) }}</h1>
+    <img src="{{ $document->data->image->url }}" alt="{{ $document->data->image->alt }}" />
+    <div>
+        {!! RichText::asHtml($document->data->description) !!}
+    </div>
+</section>
+```
+
+You can read more about templating your content in the Templating section of the documentation.
+
+## 6. Take advantage of Previews and the Prismic Toolbar
+
+In order to take advantage of all that Prismic has to offer, check out the [Previews and the Prismic Toolbar](../04-beyond-the-api/02-previews-and-the-prismic-toolbar.md) page to learn how to add these great features to your project!

--- a/docs/02-query-the-api/01-how-to-query-the-api.md
+++ b/docs/02-query-the-api/01-how-to-query-the-api.md
@@ -1,0 +1,92 @@
+# How to Query the API
+
+In order to retrieve the content from your repository, you will need to query the repository API. When you create your query you will specify exactly what it is you are looking for. You could query the repository for all the documents of certain type or retrieve the one specific document you need.
+
+Let’s take a look at how to put together queries for whatever case you need.
+
+> Check out the [Integrating with an existing Laravel project](../01-getting-started/02-integrating-with-existing-project.md) page to learn how to get set up to query documents.
+
+## The Basics
+
+In order to do any query, you'll first need to get the API object.
+
+```
+<?php
+use Prismic\Api;
+use Prismic\LinkResolver;
+use Prismic\Predicates;
+
+$api = Api::get('https://your-repo-name.prismic.io/api/v2');
+```
+
+Once you have the API object, you'll be able to retrieve content from your Prismic repository.
+
+Here's what a typical query looks like.
+
+```
+<?php
+$response = $api->query(
+    Predicates::at('document.type', 'blog-post'),
+    [ 'orderings' => '[my.blog-post.date desc]' ]
+);
+// $response contains the response object, $response->results holds the retrieved documents
+```
+
+This is the basic format of a query. In the query you have two parts, the Predicates and the Query Options.
+
+### Predicates
+
+In the above example we had the following predicate.
+
+```
+Predicates::at('document.type', 'blog-post')
+```
+
+The predicate(s) will define which documents are retrieved from the content repository. This particular example will retrieve all of the documents of the type "blog-post".
+
+The first part, "document.type" is the **path**, or what the query will be looking for. The second part the predicate in the above example is "blog-post" this is the **value** that the query is looking for.
+
+You can combine more than one predicate together to refine your query. You just need to put all your predicates into a comma-separated array like the following example.
+
+```
+[ Predicates::at('document.type', 'blog-post'),
+  Predicates::at('document.tags', ['featured']) ]
+```
+
+This particular query will retrieve all the documents of the "blog-post" type that also have the tag "featured".
+
+> You will find a list and description of all the available predicates on the [Query Predicates Reference](../02-query-the-api/02-query-predicate-reference.md) page.
+
+### Options
+
+In the second part of the query, you can include the options needed for that query. In the above example we had the following option.
+
+```
+[ 'orderings' => '[my.blog-post.date desc]' ]
+```
+
+The above specifies how the returned list of documents will be ordered. You can include more than one option, by comma separating them as shown below.
+
+```
+[ 'pageSize' => 10, 'page' => 2 ]
+```
+
+> You will find a list and description of all the available options on the [Query Options Reference](../02-query-the-api/04-query-options-reference.md) page.
+
+> **Pagination of API Results**
+>
+> When querying a Prismic repository, your results will be paginated. By default, there are 20 documents per page in the results. You can read more about how to manipulate the pagination in the [Pagination for Results](../02-query-the-api/18-pagination-for-results.md) page.
+
+Here's another example of a more advanced query with multiple predicates and multiple options.
+
+```
+<?php
+$response = $api->query(
+    [ Predicates::at('document.type', 'blog-post'),
+      Predicates::at('document.tags', ['featured']) ],
+    [ 'pageSize' => 25, 'page' => 1, 'orderings' => '[my.blog-post.date desc]' ]
+);
+// $response contains the response object, $response->results holds the retrieved documents
+```
+
+Whenever you query your content, you end up with the response object stored in the defined variable. In this case, the response object is stored in the `$response` variable.

--- a/docs/02-query-the-api/02-query-predicate-reference.md
+++ b/docs/02-query-the-api/02-query-predicate-reference.md
@@ -1,0 +1,376 @@
+# Query Predicate Reference
+
+Here you will find everything you need to learn how the query predicates work. You'll find the descriptions first for all the predicate paths and then for all the available predicates.
+
+## Predicate Path Reference
+
+Here are the different paths available when creating your query predicates.
+
+### document.type
+
+The `document.type` path is the custom type of the document. You would search this path with the API ID of the custom type you are looking for.
+
+In the example below, the API ID of the custom type is "product". This would retrieve all the documents of that custom type.
+
+```
+Predicates::at('document.type', 'product')
+```
+
+### document.id
+
+The `document.id` path is the id of the document. This is a unique ID automatically assigned to every document when it is created. It looks something like this: WGvVEDIAAAcuB3lJ
+
+The following example retrieves the one document with that ID.
+
+```
+Predicates::at('document.id', 'WGvVEDIAAAcuB3lJ')
+```
+
+### document.tags
+
+The `document.tags` path looks at the tags associated with the document. You can add tags to a document from the document edit screen.
+
+The following predicate would retrieve all of the documents with the tag "featured".
+
+```
+Predicates::at('document.tags', ['featured'])
+```
+
+Note that even when querying for one single tag, you need to put the string for the tag inside of an array.
+
+### document.first_publication_date
+
+The `document.first_publication_date` path is the date and time that the document was first published. The value for this field path is filled the first time the document is published and it never changes.
+
+The following predicate would retrieve all the documents that were first published in the year 2020.
+
+```
+Predicates::year('document.first_publication_date', 2020)
+```
+
+### document.last_publication_date
+
+The `document.last_publication_date` path is the date and time that the document was last published. The value for this field path is updated every time the document is edited and re-published.
+
+The following predicate would retrieve all the documents that were published or updated in the year 2020.
+
+```
+Predicates::year('document.last_publication_date', 2020)
+```
+
+### document
+
+The `document` path is used only with the `fulltext` predicate described below. This allows you to search an entire document for a defined word, such as "football".
+
+```
+Predicates::fulltext('document', 'football')
+```
+
+### my.{custom-type}.{field}
+
+This path allows you to query a specific field in a custom type. For {custom-type} you need to use the API ID of the custom type you want to query. For {field} you need to use the API ID of the specific field in the custom type that you need.
+
+The example below searches the "price" field in the "product" custom type.
+
+```
+Predicates::at('my.product.price', 100)
+```
+
+## Predicate Reference
+
+To use the predicates as shown below, you must make sure to include the Predicates class.
+
+```
+use Prismic/Predicates;
+```
+
+Here are descriptions of all the available predicates.
+
+### at
+
+The `at` predicate checks that the path matches the described value exactly. It takes a single value for a field or an array (only for tags).
+
+```
+Predicates::at( $path, $value )
+```
+
+| Property                                                                   | Description                                                                                    |
+| -------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------- |
+| <strong>$path</strong><br/><code>accepted paths</code>                     | <p>document.type</p><p>document.tags</p><p>document.id</p><p>my.{custom-type}.{field}</p>      |
+| <strong>$value</strong><br/><code>accepted values</code>                   | <p>single value (for all but document.tags)</p><p>array of values (only for document.tags)</p> |
+| <strong>my.{custom-type}.{field}</strong><br/><code>accepted fields</code> | <p>UID</p><p>Key Text</p><p>Select</p><p>Number</p><p>Date</p><p>Boolean</p>                   |
+
+Examples:
+
+```
+Predicates::at('document.type', 'product')
+Predicates::at('document.tags', ['Macaron', 'Cupcake'])
+Predicates::at('my.product.price', 50)
+```
+
+### not
+
+The `not` predicate checks that the path doesn't match the provided value exactly. It takes a single value as the argument.
+
+```
+Predicates::not( $path, $value )
+```
+
+| Property                                                                   | Description                                                                               |
+| -------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------- |
+| <strong>$path</strong><br/><code>accepted paths</code>                     | <p>document.type</p><p>document.tags</p><p>document.id</p><p>my.{custom-type}.{field}</p> |
+| <strong>$value</strong><br/>                                               | <p>Single value</p>                                                                       |
+| <strong>my.{custom-type}.{field}</strong><br/><code>accepted fields</code> | <p>UID</p><p>Key Text</p><p>Select</p><p>Number</p><p>Date</p><p>Boolean</p>              |
+
+Example:
+
+```
+Predicates::not('document.type', 'product')
+```
+
+### any
+
+The `any` predicate takes an array of values. It works exactly the same way as the `at` operator, but checks whether the fragment matches **any** of the values in the array.
+
+> When using this predicate with the ID or UID field, it will not necessarily return the documents in the same order as the passed array.
+
+```
+Predicates::any( $path, $values )
+```
+
+| Property                                                                   | Description                                                                               |
+| -------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------- |
+| <strong>$path</strong><br/><code>accepted paths</code>                     | <p>document.type</p><p>document.tags</p><p>document.id</p><p>my.{custom-type}.{field}</p> |
+| <strong>$values</strong><br/><code>array</code>                            | <p>Array of values</p>                                                                    |
+| <strong>my.{custom-type}.{field}</strong><br/><code>accepted fields</code> | <p>UID</p><p>Key Text</p><p>Select</p><p>Number</p><p>Date</p>                            |
+
+Example:
+
+```
+Predicates::any('document.type', ['product', 'blog-post'])
+```
+
+### in
+
+The `in` predicate is used specifically to retrieve an array of documents by their IDs or UIDs. This predicate is much more efficient at this than the `any` predicate.
+
+> This returns the documents in the same order as the passed array.
+
+```
+Predicates::in( $path, $values )
+```
+
+| Property                                               | Description                                   |
+| ------------------------------------------------------ | --------------------------------------------- |
+| <strong>$path</strong><br/><code>accepted paths</code> | <p>document.id</p><p>my.{custom-type}.uid</p> |
+| <strong>$values</strong><br/><code>array</code>        | <p>Array of IDs or UIDs</p>                   |
+
+Examples:
+
+```
+Predicates::in('document.id', ['V9rIvCQAAB0ACq6y', 'V9ZtvCcAALuRUzmO']) // IDs
+Predicates::in('my.page.uid', ['myuid1', 'myuid2']) // UIDs
+```
+
+### fulltext
+
+The `fulltext` predicate provides two capabilities
+
+1. Checking if a certain string is anywhere inside a document (this is what you should use to make your project's search engine feature)
+1. Checking if the string is contained inside a specific custom type’s Rich Text or Key Text fragment.
+
+You can search a document or a text fragment for either just one term or for multiple terms. To search for more than one term, put all the terms into a string with spaces between them as shown in the examples below.
+
+The full document search and specific field search works on the following fields:
+
+- Rich Text
+- Title
+- Key Text
+- UID
+- Select
+
+> Note that the Fulltext search is not case sensitive.
+
+```
+Predicates::fulltext( $path, $value )
+```
+
+| Property                                               | Description                                    |
+| ------------------------------------------------------ | ---------------------------------------------- |
+| <strong>$path</strong><br/><code>accepted paths</code> | <p>document</p><p>my.{custom-type}.{field}</p> |
+| <strong>$value</strong><br/><code>string</code>        | <p>Search terms</p>                            |
+
+Examples:
+
+```
+Predicates::fulltext('document', 'banana') // one term
+Predicates::fulltext('document', 'banana apple') // two terms
+Predicates::fulltext('my.product.title', 'phone') // specific field
+```
+
+### has
+
+The `has` predicate checks whether a fragment has a value. It will return all the documents of the specified type that contain a value for the specified field.
+
+Note that this predicate will restrict the results to the custom type implied in the path.
+
+```
+Predicates::has( $path )
+```
+
+| Property                                                                   | Description                                    |
+| -------------------------------------------------------------------------- | ---------------------------------------------- |
+| <strong>$path</strong><br/><code>accepted path</code>                      | <p>my.{custom-type}.{field}</p>                |
+| <strong>my.{custom-type}.{field}</strong><br/><code>accepted fields</code> | <p>All fields except for Groups and Slices</p> |
+
+Example:
+
+```
+Predicates::has('my.product.price')
+```
+
+### missing
+
+The `missing` predicate checks if a fragment doesn't have a value. It will return all the documents of the specified type that **do not** contain a value for the specified field.
+
+Note that this predicate will restrict the results to the custom type implied in the path.
+
+```
+Predicates::missing( $path )
+```
+
+| Property                                                                   | Description                                    |
+| -------------------------------------------------------------------------- | ---------------------------------------------- |
+| <strong>$path</strong><br/><code>accepted path</code>                      | <p>my.{custom-type}.{field}</p>                |
+| <strong>my.{custom-type}.{field}</strong><br/><code>accepted fields</code> | <p>All fields except for Groups and Slices</p> |
+
+Example:
+
+```
+Predicates::missing('my.product.price')
+```
+
+### similar
+
+The `similar` predicate takes the ID of a document, and returns a list of documents with similar content. This allows you to build an automated content discovery feature (for example, a "Related posts" section).
+
+Also, remember that you can combine it with other predicates. Therefore not only could you search for "similar blog posts," but you could refine that to search for "similar blog posts that mention chocolate".
+
+```
+Predicates::similar( $id, $value )
+```
+
+| Property                                         | Description                                                                                      |
+| ------------------------------------------------ | ------------------------------------------------------------------------------------------------ |
+| <strong>$id</strong><br/><code>string</code>     | <p>The document ID</p>                                                                           |
+| <strong>$value</strong><br/><code>integer</code> | <p>The maximum number of documents that a term may appear in to still be considered relevant</p> |
+
+Example:
+
+```
+Predicates::similar('VkRmhykAAFA6PoBj', 10)
+```
+
+### near
+
+The `near` predicate checks that the value in the path is within the radius of the given coordinates.
+
+> This predicate will only work for a GeoPoint field.
+
+> Note that the measure of distance used for the radius is in km.
+
+The near predicate will order the results from nearest to farthest from the given coordinates.
+
+```
+Predicates::near( $path, $latitude, $longitude, $radius )
+```
+
+| Property                                              | Description                                       |
+| ----------------------------------------------------- | ------------------------------------------------- |
+| <strong>$path</strong><br/><code>accepted path</code> | <p>my.{custom-type}.{field}</p>                   |
+| <strong>$latitude</strong><br/><code>float</code>     | <p>Latitude of the center of the search area</p>  |
+| <strong>$longitude</strong><br/><code>float</code>    | <p>Longitude of the center of the search area</p> |
+| <strong>$radius</strong><br/><code>float</code>       | <p>Radius of search in kilometers</p>             |
+
+Example:
+
+```
+Predicates::near('my.restaurant.location', 9.656896299, -9.77508544, 10)
+```
+
+## Number based Predicates
+
+There are a few predicates that are specifically used for the Number field.
+
+Note that when using any of these predicates, you will limit the results of the query to the specified custom type.
+
+### lt (Less than)
+
+The `lt` predicate checks that the value in the number field is less than the value passed into the predicate.
+
+> This is a strict less-than operator, it will not give values equal to the specified value.
+
+```
+Predicates::lt( $path, $value )
+```
+
+| Property                                              | Description                     |
+| ----------------------------------------------------- | ------------------------------- |
+| <strong>$path</strong><br/><code>accepted path</code> | <p>my.{custom-type}.{field}</p> |
+| <strong>$value</strong><br/><code>float</code>        | <p>Number value</p>             |
+
+Examples:
+
+```
+Predicates::lt('my.instructions.numberOfSteps', 10)
+Predicates::lt('my.product.price', 49.99)
+```
+
+### gt (Greater than)
+
+The `gt` predicate checks that the value in the number field is greater than the value passed into the predicate.
+
+> This is a strict greater-than operator, it will not give values equal to the specified value.
+
+```
+Predicates::gt( $path, $value )
+```
+
+| Property                                              | Description                     |
+| ----------------------------------------------------- | ------------------------------- |
+| <strong>$path</strong><br/><code>accepted path</code> | <p>my.{custom-type}.{field}</p> |
+| <strong>$value</strong><br/><code>float</code>        | <p>Number value</p>             |
+
+Examples:
+
+```
+Predicates::gt('my.rental.numberOfBedrooms', 2)
+Predicates::gt('my.product.price', 9.99)
+```
+
+### inRange
+
+The `inRange` predicate checks that the value in the path is within the two values passed into the predicate.
+
+> This is an inclusive search, it will include values equal to the upper and lower limits.
+
+```
+Predicates::inRange( $path, $lowerLimit, $upperLimit )
+```
+
+| Property                                               | Description                     |
+| ------------------------------------------------------ | ------------------------------- |
+| <strong>$path</strong><br/><code>accepted paths</code> | <p>my.{custom-type}.{field}</p> |
+| <strong>$lowerLimit</strong><br/><code>float</code>    | <p>Lower limit of the range</p> |
+| <strong>$upperLimit</strong><br/><code>float</code>    | <p>Upper limit of the range</p> |
+
+Examples:
+
+```
+Predicates::inRange('my.album.track-count', 7, 10)
+Predicates::inRange('my.product.price', 9.99, 49.99)
+```
+
+## Date & Time based Predicates
+
+There are a number of predicates that are specifically used for the Date and Timestamp fields. You can read more about them on the [Date & Time based Predicate Reference](../02-query-the-api/03-date-and-time-based-predicate-reference.md) page.

--- a/docs/02-query-the-api/03-date-and-time-based-predicate-reference.md
+++ b/docs/02-query-the-api/03-date-and-time-based-predicate-reference.md
@@ -1,0 +1,471 @@
+# Date & Time Based Predicate Reference
+
+This page describes and gives examples for all the date and time based predicates you can use when creating queries with the prismic.io PHP development kit.
+
+To use the predicates as shown below, you must make sure to include the Predicates class.
+
+```
+use Prismic/Predicates;
+```
+
+All of these predicates will work when used with either the Date or Timestamp fields, as well as the first and last publication dates.
+
+> Note that when using any of these predicates with either a Date or Timestamp field, you will limit the results of the query to the specified custom type.
+
+## dateAfter
+
+The `dateAfter` predicate checks that the value in the path is after the date value passed into the predicate.
+
+This will NOT include anything with a date equal to the input value.
+
+```
+Predicates::dateAfter( $path, $date )
+```
+
+| Property                                                     | Description                                                                                                |
+| ------------------------------------------------------------ | ---------------------------------------------------------------------------------------------------------- |
+| <strong>$path</strong><br/><code>accepted paths</code>       | <p>document.first_publication_date</p><p>document.last_publication_date</p><p>my.{custom-type}.{field}</p> |
+| <strong>$date</strong><br/><code>accepted date values</code> | <p>DateTime object</p><p>String in the following format: “YYYY-MM-DD”</p>                                  |
+
+Examples:
+
+```
+Predicates::dateAfter('document.first_publication_date', new DateTime('2017-05-18'))
+Predicates::dateAfter('document.last_publication_date', '2017-05-18')
+Predicates::dateAfter('my.article.release-date', '2017-01-22')
+```
+
+## dateBefore
+
+The `dateBefore` predicate checks that the value in the path is before the date value passed into the predicate.
+
+This will NOT include anything with a date equal to the input value.
+
+```
+Predicates::dateBefore( $path, $date )
+```
+
+| Property                                                     | Description                                                                                                |
+| ------------------------------------------------------------ | ---------------------------------------------------------------------------------------------------------- |
+| <strong>$path</strong><br/><code>accepted paths</code>       | <p>document.first_publication_date</p><p>document.last_publication_date</p><p>my.{custom-type}.{field}</p> |
+| <strong>$date</strong><br/><code>accepted date values</code> | <p>DateTime object</p><p>String in the following format: “YYYY-MM-DD”</p>                                  |
+
+Examples:
+
+```
+Predicates::dateBefore('document.first_publication_date', '2016-09-19')
+Predicates::dateBefore('document.last_publication_date', new DateTime('2016-10-15'))
+Predicates::dateBefore('my.post.date', new DateTime('2017-08-24'))
+```
+
+## dateBetween
+
+The `dateBetween` predicate checks that the value in the path is within the date values passed into the predicate.
+
+```
+Predicates::dateBetween( $path, $startDate, $endDate )
+```
+
+| Property                                                          | Description                                                                                                |
+| ----------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------- |
+| <strong>$path</strong><br/><code>accepted paths</code>            | <p>document.first_publication_date</p><p>document.last_publication_date</p><p>my.{custom-type}.{field}</p> |
+| <strong>$startDate</strong><br/><code>accepted date values</code> | <p>DateTime object</p><p>String in the following format: &quot;YYYY-MM-DD&quot;</p>                        |
+| <strong>$endDate</strong><br/><code>accepted date values</code>   | <p>DateTime object</p><p>String in the following format: &quot;YYYY-MM-DD&quot;</p>                        |
+
+Examples:
+
+```
+Predicates::dateBetween('document.first_publication_date', '2017-01-16', '2017-01-20')
+Predicates::dateBetween('document.last_publication_date', new DateTime('2017-01-16'), new DateTime('2017-01-20'))
+Predicates::dateBetween('my.blog-post.post-date', '2017-01-16', '2017-01-20')
+```
+
+## dayOfMonth
+
+The `dayOfMonth` predicate checks that the value in the path is equal to the day of the month passed into the predicate.
+
+```
+Predicates::dayOfMonth( $path, $day )
+```
+
+| Property                                               | Description                                                                                                |
+| ------------------------------------------------------ | ---------------------------------------------------------------------------------------------------------- |
+| <strong>$path</strong><br/><code>accepted paths</code> | <p>document.first_publication_date</p><p>document.last_publication_date</p><p>my.{custom-type}.{field}</p> |
+| <strong>$day</strong><br/><code>integer</code>         | <p>Day of the month</p>                                                                                    |
+
+Examples:
+
+```
+Predicates::dayOfMonth('document.first_publication_date', 22)
+Predicates::dayOfMonth('document.last_publication_date', 30)
+Predicates::dayOfMonth('my.post.date', 14)
+```
+
+## dayOfMonthAfter
+
+The `dayOfMonthAfter` predicate checks that the value in the path is after the day of the month passed into the predicate.
+
+Note that this will return only the days after the specified day of the month. It will not return any documents where the day is equal to the specified day.
+
+```
+Predicates::dayOfMonthAfter( $path, $day )
+```
+
+| Property                                               | Description                                                                                                |
+| ------------------------------------------------------ | ---------------------------------------------------------------------------------------------------------- |
+| <strong>$path</strong><br/><code>accepted paths</code> | <p>document.first_publication_date</p><p>document.last_publication_date</p><p>my.{custom-type}.{field}</p> |
+| <strong>$day</strong><br/><code>integer</code>         | <p>Day of the month</p>                                                                                    |
+
+Examples:
+
+```
+Predicates::dayOfMonthAfter('document.first_publication_date', 1)
+Predicates::dayOfMonthAfter('document.last_publication_date', 10)
+Predicates::dayOfMonthAfter('my.event.date-and-time', 15)
+```
+
+## dayOfMonthBefore
+
+The `dayOfMonthBefore` predicate checks that the value in the path is before the day of the month passed into the predicate.
+
+Note that this will return only the days before the specified day of the month. It will not return any documents where the date is equal to the specified day.
+
+```
+Predicates::dayOfMonthBefore( $path, $day )
+```
+
+| Property                                               | Description                                                                                                |
+| ------------------------------------------------------ | ---------------------------------------------------------------------------------------------------------- |
+| <strong>$path</strong><br/><code>accepted paths</code> | <p>document.first_publication_date</p><p>document.last_publication_date</p><p>my.{custom-type}.{field}</p> |
+| <strong>$day</strong><br/><code>integer</code>         | <p>Day of the month</p>                                                                                    |
+
+Examples:
+
+```
+Predicates::dayOfMonthBefore('document.first_publication_date', 30)
+Predicates::dayOfMonthBefore('document.last_publication_date', 10)
+Predicates::dayOfMonthBefore('my.blog-post.release-date', 23)
+```
+
+## dayOfWeek
+
+The `dayOfWeek` predicate checks that the value in the path is equal to the day of the week passed into the predicate.
+
+```
+Predicates::dayOfWeek( $path, $day )
+```
+
+| Property                                                   | Description                                                                                                |
+| ---------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------- |
+| <strong>$path</strong><br/><code>accepted paths</code>     | <p>document.first_publication_date</p><p>document.last_publication_date</p><p>my.{custom-type}.{field}</p> |
+| <strong>$day</strong><br/><code>string\* or integer</code> | <pre>&#39;monday&#39;, &#39;mon&#39;, or 1                                                                 |
+
+&#39;tuesday&#39;, &#39;tue&#39;, or 2
+&#39;wednesday&#39;, &#39;wed&#39;, or 3
+&#39;thursday&#39;, &#39;thu&#39;, or 4
+&#39;friday&#39;, &#39;fri&#39;, or 5
+&#39;saturday&#39;, &#39;sat&#39;, or 6
+&#39;sunday&#39;, &#39;sun&#39;, or 7</pre>|
+
+- For any of the string input values you can use either first letter capitalized, all lowercase, or all uppercase. For example, "Monday", "monday", and "MONDAY" are all accepted values.
+
+Examples:
+
+```
+Predicates::dayOfWeek('document.first_publication_date', 'monday')
+Predicates::dayOfWeek('document.last_publication_date', 'sun')
+Predicates::dayOfWeek('my.concert.show-date', 'Friday')
+```
+
+## dayOfWeekAfter
+
+The `dayOfWeekAfter` predicate checks that the value in the path is after the day of the week passed into the predicate.
+
+This predicate uses Monday as the beginning of the week:
+
+1. Monday
+1. Tuesday
+1. Wednesday
+1. Thursday
+1. Friday
+1. Saturday
+1. Sunday
+
+Note that this will return only the days after the specified day of the week. It will not return any documents where the day is equal to the specified day.
+
+```
+Predicates::dayOfWeekAfter( $path, $day )
+```
+
+| Property                                                   | Description                                                                                                |
+| ---------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------- |
+| <strong>$path</strong><br/><code>accepted paths</code>     | <p>document.first_publication_date</p><p>document.last_publication_date</p><p>my.{custom-type}.{field}</p> |
+| <strong>$day</strong><br/><code>string\* or integer</code> | <pre>&#39;monday&#39;, &#39;mon&#39;, or 1                                                                 |
+
+&#39;tuesday&#39;, &#39;tue&#39;, or 2
+&#39;wednesday&#39;, &#39;wed&#39;, or 3
+&#39;thursday&#39;, &#39;thu&#39;, or 4
+&#39;friday&#39;, &#39;fri&#39;, or 5
+&#39;saturday&#39;, &#39;sat&#39;, or 6
+&#39;sunday&#39;, &#39;sun&#39;, or 7</pre>|
+
+- For any of the string input values you can use either first letter capitalized, all lowercase, or all uppercase. For example, "Monday", "monday", and "MONDAY" are all accepted values.
+
+Examples:
+
+```
+Predicates::dayOfWeekAfter('document.first_publication_date', 'fri')
+Predicates::dayOfWeekAfter('document.last_publication_date', 'Thu')
+Predicates::dayOfWeekAfter('my.blog-post.date', 'tuesday')
+```
+
+## dayOfWeekBefore
+
+The `dayOfWeekBefore` predicate checks that the value in the path is before the day of the week passed into the predicate.
+
+This predicate uses Monday as the beginning of the week:
+
+1. Monday
+1. Tuesday
+1. Wednesday
+1. Thursday
+1. Friday
+1. Saturday
+1. Sunday
+
+Note that this will return only the days before the specified day of the week. It will not return any documents where the day is equal to the specified day.
+
+```
+Predicates::dayOfWeekBefore( $path, $day )
+```
+
+| Property                                                   | Description                                                                                                |
+| ---------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------- |
+| <strong>$path</strong><br/><code>accepted paths</code>     | <p>document.first_publication_date</p><p>document.last_publication_date</p><p>my.{custom-type}.{field}</p> |
+| <strong>$day</strong><br/><code>string\* or integer</code> | <pre>&#39;monday&#39;, &#39;mon&#39;, or 1                                                                 |
+
+&#39;tuesday&#39;, &#39;tue&#39;, or 2
+&#39;wednesday&#39;, &#39;wed&#39;, or 3
+&#39;thursday&#39;, &#39;thu&#39;, or 4
+&#39;friday&#39;, &#39;fri&#39;, or 5
+&#39;saturday&#39;, &#39;sat&#39;, or 6
+&#39;sunday&#39;, &#39;sun&#39;, or 7</pre>|
+
+- For any of the string input values you can use either first letter capitalized, all lowercase, or all uppercase. For example, "Monday", "monday", and "MONDAY" are all accepted values.
+
+Examples:
+
+```
+Predicates::dayOfWeekBefore('document.first_publication_date', 'Wed')
+Predicates::dayOfWeekBefore('document.last_publication_date', 'saturday')
+Predicates::dayOfWeekBefore('my.page.release-date', 'Saturday')
+```
+
+## month
+
+The `month` predicate checks that the value in the path occurs in the month value passed into the predicate.
+
+```
+Predicates::month( $path, $month )
+```
+
+| Property                                                     | Description                                                                                                |
+| ------------------------------------------------------------ | ---------------------------------------------------------------------------------------------------------- |
+| <strong>$path</strong><br/><code>accepted paths</code>       | <p>document.first_publication_date</p><p>document.last_publication_date</p><p>my.{custom-type}.{field}</p> |
+| <strong>$month</strong><br/><code>string\* or integer</code> | <pre>&#39;january&#39;, &#39;jan&#39;, or 1                                                                |
+
+&#39;february&#39;, &#39;feb&#39;, or 2
+&#39;march&#39;, &#39;mar&#39;, or 3
+&#39;april&#39;, &#39;apr&#39;, or 4
+&#39;may&#39; or 5
+&#39;june&#39;, &#39;jun&#39;, or 6
+&#39;july&#39;, &#39;jul&#39;, or 7
+&#39;august&#39;, &#39;aug&#39;, or 8
+&#39;september&#39;, &#39;sep&#39;, or 9
+&#39;october&#39;, &#39;oct&#39;, or 10
+&#39;november&#39;, &#39;nov&#39;, or 11
+&#39;december&#39;, &#39;dec&#39;, or 12</pre>|
+
+- For any of the string input values you can use either first letter capitalized, all lowercase, or all uppercase. For example, "January", "january", and "JANUARY" are all accepted values.
+
+Examples:
+
+```
+Predicates::month('document.first_publication_date', 'august')
+Predicates::month('document.last_publication_date', 'Sep')
+Predicates::month('my.blog-post.date', 1)
+```
+
+## monthAfter
+
+The `monthAfter` predicate checks that the value in the path occurs in any month after the value passed into the predicate.
+
+Note that this will only return documents where the date is after the specified month. It will not return any documents where the date is within the specified month.
+
+```
+Predicates::monthAfter( $path, $month )
+```
+
+| Property                                                     | Description                                                                                                |
+| ------------------------------------------------------------ | ---------------------------------------------------------------------------------------------------------- |
+| <strong>$path</strong><br/><code>accepted paths</code>       | <p>document.first_publication_date</p><p>document.last_publication_date</p><p>my.{custom-type}.{field}</p> |
+| <strong>$month</strong><br/><code>string\* or integer</code> | <pre>&#39;january&#39;, &#39;jan&#39;, or 1                                                                |
+
+&#39;february&#39;, &#39;feb&#39;, or 2
+&#39;march&#39;, &#39;mar&#39;, or 3
+&#39;april&#39;, &#39;apr&#39;, or 4
+&#39;may&#39; or 5
+&#39;june&#39;, &#39;jun&#39;, or 6
+&#39;july&#39;, &#39;jul&#39;, or 7
+&#39;august&#39;, &#39;aug&#39;, or 8
+&#39;september&#39;, &#39;sep&#39;, or 9
+&#39;october&#39;, &#39;oct&#39;, or 10
+&#39;november&#39;, &#39;nov&#39;, or 11
+&#39;december&#39;, &#39;dec&#39;, or 12</pre>|
+
+- For any of the string input values you can use either first letter capitalized, all lowercase, or all uppercase. For example, "January", "january", and "JANUARY" are all accepted values.
+
+Examples:
+
+```
+Predicates::monthAfter('document.first_publication_date', 'February')
+Predicates::monthAfter('document.last_publication_date', 6)
+Predicates::monthAfter('my.article.date', 'oct')
+```
+
+## monthBefore
+
+The `monthBefore` predicate checks that the value in the path occurs in any month before the value passed into the predicate.
+
+Note that this will only return documents where the date is before the specified month. It will not return any documents where the date is within the specified month.
+
+```
+Predicates::monthBefore( $path, $month )
+```
+
+| Property                                                     | Description                                                                                                |
+| ------------------------------------------------------------ | ---------------------------------------------------------------------------------------------------------- |
+| <strong>$path</strong><br/><code>accepted paths</code>       | <p>document.first_publication_date</p><p>document.last_publication_date</p><p>my.{custom-type}.{field}</p> |
+| <strong>$month</strong><br/><code>string\* or integer</code> | <pre>&#39;january&#39;, &#39;jan&#39;, or 1                                                                |
+
+&#39;february&#39;, &#39;feb&#39;, or 2
+&#39;march&#39;, &#39;mar&#39;, or 3
+&#39;april&#39;, &#39;apr&#39;, or 4
+&#39;may&#39; or 5
+&#39;june&#39;, &#39;jun&#39;, or 6
+&#39;july&#39;, &#39;jul&#39;, or 7
+&#39;august&#39;, &#39;aug&#39;, or 8
+&#39;september&#39;, &#39;sep&#39;, or 9
+&#39;october&#39;, &#39;oct&#39;, or 10
+&#39;november&#39;, &#39;nov&#39;, or 11
+&#39;december&#39;, &#39;dec&#39;, or 12</pre>|
+
+- For any of the string input values you can use either first letter capitalized, all lowercase, or all uppercase. For example, "January", "january", and "JANUARY" are all accepted values.
+
+Examples:
+
+```
+Predicates::monthBefore('document.first_publication_date', 8)
+Predicates::monthBefore('document.last_publication_date', 'june')
+Predicates::monthBefore('my.blog-post.release-date', 'Sep')
+```
+
+## year
+
+The `year` predicate checks that the value in the path occurs in the year value passed into the predicate.
+
+```
+Predicates::year( $path, $year )
+```
+
+| Property                                               | Description                                                                                                |
+| ------------------------------------------------------ | ---------------------------------------------------------------------------------------------------------- |
+| <strong>$path</strong><br/><code>accepted paths</code> | <p>document.first_publication_date</p><p>document.last_publication_date</p><p>my.{custom-type}.{field}</p> |
+| <strong>$year</strong><br/><code>integer</code>        | <p>Year</p>                                                                                                |
+
+Examples:
+
+```
+Predicates::year('document.first_publication_date', 2016)
+Predicates::year('document.last_publication_date', 2017)
+Predicates::year('my.employee.birthday', 1986)
+```
+
+## hour
+
+The `hour` predicate checks that the value in the path occurs within the hour value passed into the predicate.
+
+This uses the 24 hour system, starting at 0 and going through 23.
+
+Note that this predicate will technically work for a Date field, but won’t be very useful. All date field values are automatically given an hour of 0.
+
+```
+Predicates::hour( $path, $hour )
+```
+
+| Property                                               | Description                                                                                                |
+| ------------------------------------------------------ | ---------------------------------------------------------------------------------------------------------- |
+| <strong>$path</strong><br/><code>accepted paths</code> | <p>document.first_publication_date</p><p>document.last_publication_date</p><p>my.{custom-type}.{field}</p> |
+| <strong>$hour</strong><br/><code>integer</code>        | <p>Hour between 0 and 23</p>                                                                               |
+
+Examples:
+
+```
+Predicates::hour('document.first_publication_date', 12)
+Predicates::hour('document.last_publication_date', 8)
+Predicates::hour('my.event.date-and-time', 19)
+```
+
+## hourAfter
+
+The `hourAfter` predicate checks that the value in the path occurs after the hour value passed into the predicate.
+
+This uses the 24 hour system, starting at 0 and going through 23.
+
+> Note that this will only return documents where the timestamp is after the specified hour. It will not return any documents where the timestamp is within the specified hour.
+
+This predicate will technically work for a Date field, but won’t be very useful. All date field values are automatically given an hour of 0.
+
+```
+Predicates::hourAfter( $path, $hour )
+```
+
+| Property                                               | Description                                                                                                |
+| ------------------------------------------------------ | ---------------------------------------------------------------------------------------------------------- |
+| <strong>$path</strong><br/><code>accepted paths</code> | <p>document.first_publication_date</p><p>document.last_publication_date</p><p>my.{custom-type}.{field}</p> |
+| <strong>$hour</strong><br/><code>integer</code>        | <p>Hour between 0 and 23</p>                                                                               |
+
+Examples:
+
+```
+Predicates::hourAfter('document.first_publication_date', 21)
+Predicates::hourAfter('document.last_publication_date', 8)
+Predicates::hourAfter('my.blog-post.releaseDate', 16)
+```
+
+## hourBefore
+
+The `hourBefore` predicate checks that the value in the path occurs before the hour value passed into the predicate.
+
+This uses the 24 hour system, starting at 0 and going through 23.
+
+> Note that this will only return documents where the timestamp is before the specified hour. It will not return any documents where the timestamp is within the specified hour.
+
+This predicate will technically work for a Date field, but won’t be very useful. All date field values are automatically given an hour of 0.
+
+```
+Predicates::hourBefore( $path, $hour )
+```
+
+| Property                                               | Description                                                                                                |
+| ------------------------------------------------------ | ---------------------------------------------------------------------------------------------------------- |
+| <strong>$path</strong><br/><code>accepted paths</code> | <p>document.first_publication_date</p><p>document.last_publication_date</p><p>my.{custom-type}.{field}</p> |
+| <strong>$hour</strong><br/><code>integer</code>        | <p>Hour between 0 and 23</p>                                                                               |
+
+Examples:
+
+```
+Predicates::hourBefore('document.first_publication_date', 10)
+Predicates::hourBefore('document.last_publication_date', 12)
+Predicates::hourBefore('my.event.dateAndTime', 12)
+```

--- a/docs/02-query-the-api/04-query-options-reference.md
+++ b/docs/02-query-the-api/04-query-options-reference.md
@@ -1,0 +1,196 @@
+# Query Options reference
+
+Here you will find a complete reference about the various query options.
+
+## after
+
+The `after` option can be used along with the orderings option. It will remove all the documents except for those after the specified document in the list.
+
+To clarify, let’s say you have a query that return the following documents in this order:
+
+- `V9Zt3icAAAl8Uzob (Page 1)`
+- `PqZtvCcAALuRUzmO (Page 2)`
+- `VkRmhykAAFA6PoBj (Page 3)`
+- `V4Fs8rDbAAH9Pfow (Page 4)`
+- `G8ZtxQhAALuSix6R (Page 5)`
+- `Ww9yuAvdAhl87wh6 (Page 6)`
+
+If you add the `after` option and specify page 3, “`VkRmhykAAFA6PoBj`”, your query will return the following:
+
+- `V4Fs8rDbAAH9Pfow (Page 4)`
+- `G8ZtxQhAALuSix6R (Page 5)`
+- `Ww9yuAvdAhl87wh6 (Page 6)`
+
+By reversing the orderings in your query, you can use this same method to retrieve all the documents before the specified document.
+
+This option is useful when creating a navigation for a blog.
+
+```
+[ 'after' => 'VkRmhykAAFA6PoBj' ]
+```
+
+## fetch
+
+The `fetch` option is used to make queries faster by only retrieving the specified field(s).
+
+To retrieve a single field, simply specify the field as shown below.
+
+```css
+[ 'fetch' => 'product.title' ]
+```
+
+To retrieve more than one field, you just need to comma separate all the fields you wish included in the response.
+
+```css
+[ 'fetch' => 'product.title, product.price']
+```
+
+## fetchLinks
+
+The `fetchLinks` option allows you to retrieve a specific content field from a linked document and add it to the document response object.
+
+Note that this will only retrieve content of the following field types:
+
+- Color
+- Content Relationship
+- Date
+- Image
+- Key Text
+- Number
+- Rich Text (but only the first element)
+- Select
+- Timestamp
+
+It is **not** possible to retrieve the following content field types:
+
+- Embed
+- GeoPoint
+- Link
+- Link to Media
+- Rich Text (anything other than the first element)
+- Title
+- Any field in a Group or Slice
+
+The value you enter for the fetchLinks option needs to take the following format:
+
+```css
+[ 'fetchLinks' => '{custom-type}.{field}' ]
+```
+
+| Property                            | Description                                                                  |
+| ----------------------------------- | ---------------------------------------------------------------------------- |
+| <strong>{custom-type}</strong><br/> | <p>The custom type API-ID of the linked document</p>                         |
+| <strong>{field}</strong><br/>       | <p>The API-ID of the field you wish to retrieve from the linked document</p> |
+
+To view a complete example of how this option works, view the example on the [Fetch Linked Document Fields](../02-query-the-api/16-fetch-linked-items.md) page.
+
+```css
+[ 'fetchLinks' => 'author.full_name' ]
+[ 'fetchLinks' => 'author.first-name, author.last-name' ]
+```
+
+## lang
+
+The `lang` option defines the language code for the results of your query.
+
+### Specify a particular language/region
+
+You can use the *lang* option to specify a particular language/region you wish to query by. You just need to set the lang value to the desired language code, for example "en-us" for American English.
+
+> If no *lang* option is provided, then the query will default to the master language of the repository.
+
+```css
+[ 'lang' => 'en-us' ]
+```
+
+### Query all languages
+
+You can also use the *lang* option to specify that you want to query documents in all available languages. Simply set the *lang* option to the wildcard value `*`.
+
+```
+[ 'lang' => '*' ]
+```
+
+To view a complete example of how this option works, view the examples on the [Query by Language](../02-query-the-api/19-query-by-language.md) page.
+
+## orderings
+
+The `orderings` option orders the results by the specified field(s). You can specify as many fields as you want.
+
+| Property                                | Description                                                                                    |
+| --------------------------------------- | ---------------------------------------------------------------------------------------------- |
+| <strong>lowest to highest</strong><br/> | <p>It will automatically order the field from lowest to highest</p>                            |
+| <strong>highest to lowest</strong><br/> | <p>Use &quot;desc&quot; next to the field name to instead order it from greatest to lowest</p> |
+
+```javascript
+[ 'orderings' => '[my.product.price]' ] // lowest to highest
+[ 'orderings' => '[my.product.price desc]' ] // highest to lowest
+```
+
+### Multiple orderings
+
+You can specify more than one field to order your results by. To do so, simply add more than one field in the array.
+
+The results will be ordered by the first field in the array. If any of the results have the same value for that initial sort, they will then be sorted by the next specified field.
+
+Here is an example that first sorts the products by price from lowest to highest. If any of the products have the same price, then they will be sorted by their titles.
+
+```css
+[ 'orderings' => '[my.product.price, my.product.title]' ]
+```
+
+### Sort by publication date
+
+It is also possible to order documents by their first or last publication dates.
+
+| Property                                     | Description                                                                    |
+| -------------------------------------------- | ------------------------------------------------------------------------------ |
+| <strong>first_publication_date</strong><br/> | <p>The date that the document was originally published for the first time</p>  |
+| <strong>last_publication_date</strong><br/>  | <p>The most recent date that the document has been published after editing</p> |
+
+```css
+[ 'orderings' => '[document.first_publication_date]' ]
+[ 'orderings' => '[document.last_publication_date]' ]
+```
+
+## page
+
+The `page` option defines the pagination for the result of your query.
+
+Defaults to "1", corresponding to the first page.
+
+| Property                                        | Description                                         |
+| ----------------------------------------------- | --------------------------------------------------- |
+| <strong>value</strong><br/><code>integer</code> | <p>page index (1 = 1st page, 2 = 2nd page, ...)</p> |
+
+```css
+[ 'page' => 2 ]
+```
+
+## pageSize
+
+The `pageSize` option defines the maximum number of documents that the API will return for your query.
+
+Default is 20, max is 100.
+
+| Property                                        | Description                          |
+| ----------------------------------------------- | ------------------------------------ |
+| <strong>value</strong><br/><code>integer</code> | <p>page size (between 1 and 100)</p> |
+
+```css
+[ 'pageSize' => 100 ]
+```
+
+## ref
+
+The `ref` option defines which version of your content to query.
+
+By default the Prismic PHP development kit will use the master ref to retrieve the currently published documents.
+
+| Property                                       | Description                                        |
+| ---------------------------------------------- | -------------------------------------------------- |
+| <strong>value</strong><br/><code>string</code> | <p>Master, Release, Experiment, or Preview ref</p> |
+
+```css
+[ 'ref' => 'Wst7PCgAAHUAvviX' ]
+```

--- a/docs/02-query-the-api/05-query-helper-functions.md
+++ b/docs/02-query-the-api/05-query-helper-functions.md
@@ -1,0 +1,125 @@
+# Query Helper Functions
+
+We've included helper functions to make creating certain queries quicker and easier when developing with Prismic and Laravel.
+
+## getByUID
+
+```css
+getByUID( custom-type, uid, options )
+```
+
+The `getByUID` function is used to query the specified custom type by a certain UID value. This requires that the custom type of the document contains the UID field.
+
+This function will only ever retrieve one document as there can only be one instance of a given UID value for each custom type & language.
+
+| Property                                             | Description                                                           |
+| ---------------------------------------------------- | --------------------------------------------------------------------- |
+| <strong>custom-type</strong><br/><code>string</code> | <p>(required) The API-ID of the custom type you are searching for</p> |
+| <strong>uid</strong><br/><code>string</code>         | <p>(required) The UID of the document you want to retrieve</p>        |
+| <strong>options</strong><br/><code>array</code>      | <p>(optional) An array with option parameters and values</p>          |
+
+Here is an example that queries a document of the type “page” by its uid “about-us”.
+
+```php
+<?php
+$document = $api->getByUID('page', 'about-us');
+// $document contains the document content
+```
+
+Here is an example with options that specifies a particular language to query.
+
+```php
+<?php
+$options = [ 'lang' => 'en-us' ];
+$document = $api->getByUID('page', 'about-us', $options);
+// $document contains the document content
+```
+
+## getByID
+
+```css
+getByID( id, options )
+```
+
+The `getByID` function is used to query a certain document by its document ID. Every document is automatically assigned a unique id when it is created. The ID will look something like this: ‘WAjgAygABN3B0a-a’.
+
+This function will only ever retrieve one document as each document has a unique ID value.
+
+| Property                                        | Description                                                   |
+| ----------------------------------------------- | ------------------------------------------------------------- |
+| <strong>id</strong><br/><code>string</code>     | <p>(required) The id of the document you want to retrieve</p> |
+| <strong>options</strong><br/><code>array</code> | <p>(optional) An array with option parameters and values</p>  |
+
+Here is an example that queries a document by its ID "WAjgAygABN3B0a-a".
+
+```php
+<?php
+$document = $api->getByID('WAjgAygABN3B0a-a');
+// $document contains the document content
+```
+
+Here is an example that adds options.
+
+```php
+<?php
+$options = [ 'fetch' => 'product.title' ];
+$document = $api->getByID('WAjgAygABN3B0a-a', $options);
+// $document contains the document content
+```
+
+## getByIDs
+
+```css
+getByIDs( ids, options )
+```
+
+The `getByIDs` function is used to query multiple documents by their ids.
+
+This will return the documents in the same order specified in the array, unless options are added to sort them otherwise.
+
+| Property                                        | Description                                                                              |
+| ----------------------------------------------- | ---------------------------------------------------------------------------------------- |
+| <strong>ids</strong><br/><code>array</code>     | <p>(required) An array of strings with the ids of the documents you want to retrieve</p> |
+| <strong>options</strong><br/><code>array</code> | <p>(optional) An array with option parameters and values</p>                             |
+
+Here is an example that queries multiple documents by their ids.
+
+```php
+<?php
+$ids = ['WAjgAygAAN3B0a-a', 'WC7GECUAAHBHQd-Y', 'WEE_gikAAC2feA-z'];
+$response = $api->getByIDs($ids);
+// $response contains the response object, $response->results holds the retrieved documents
+```
+
+Here is an example with options that sort the documents by their titles.
+
+```php
+<?php
+$ids = ['WAjgAygAAN3B0a-a', 'WC7GECUAAHBHQd-Y', 'WEE_gikAAC2feA-z'];
+$options = [ 'orderings' => '[my.page.title]' ];
+$response = $api->getByIDs($ids);
+// $response contains the response object, $response->results holds the retrieved documents
+```
+
+## getSingle
+
+```css
+getSingle( custom-type, options )
+```
+
+The `getSingle` function is used to query the document of a Single custom type. Single custom types only allow for the creation of one document of that type.
+
+This will only ever retrieve one document.
+
+| Property                                             | Description                                                                 |
+| ---------------------------------------------------- | --------------------------------------------------------------------------- |
+| <strong>custom-type</strong><br/><code>string</code> | <p>(required) The API ID of the single custom type you want to retrieve</p> |
+| <strong>options</strong><br/><code>array</code>      | <p>(optional) An array with option parameters and values</p>                |
+
+Here is an example that retrieves the document of the Single type "navigation".
+
+```php
+<?php
+$document = $api->getSingle('navigation');
+// $document contains the document content
+```

--- a/docs/02-query-the-api/06-query-single-type.md
+++ b/docs/02-query-the-api/06-query-single-type.md
@@ -1,0 +1,30 @@
+# Query a Single Type document
+
+Here we discuss how to retrieve the content for a Single type document.
+
+## getSingle helper function
+
+In this example we use the `getSingle` helper function to query the single instance of the custom type "navigation".
+
+```
+<?php
+$document = $api->getSingle('navigation');
+// $document contains the document content
+```
+
+## Without the helper
+
+You can perform the same query without using the helper function. Here we again query the single document of the type "navigation".
+
+```
+<?php
+$response = $api->query(Predicates::at('document.type', 'navigation'));
+$document = $response->results[0];
+// $document contains the document content
+```
+
+> **Querying by Language**
+>
+> Note that if you are trying to query a document that isn't in the master language of your repository this way, you will need to specify the language code or wildcard language value. You can read how to do this on the [Query by Language page](../02-query-the-api/19-query-by-language.md).
+>
+> If you are using the query helper function above, you do not need to do this.

--- a/docs/02-query-the-api/07-query-by-id-or-uid.md
+++ b/docs/02-query-the-api/07-query-by-id-or-uid.md
@@ -1,0 +1,110 @@
+# Query Documents by ID or UID
+
+You can retrieve either multiple documents or a single one by their document ID or UID.
+
+> **Querying by Language**
+>
+> Note that if you are trying to query a document that isn't in the master language of your repository, you will need to specify the language code or wildcard language value. You can read how to do this on the [Query by Language page](../02-query-the-api/19-query-by-language.md).
+>
+> If you are using one of the query helper functions below, you do not need to do this. The only exception is the `getByUID` helper which is explained below.
+
+## Query a document by ID
+
+We've created a helper function that makes it easy to query by ID, but it is also possible to do this without the helper function.
+
+### getByID helper function
+
+Here is an example that shows how to query a document by its ID using the `getByID` helper function.
+
+```
+<?php
+$document = $api->getByID('WAjgAygABN3B0a-a');
+// $document contains the document content
+```
+
+### Without the helper function
+
+Here we perform the same query for a document by its ID without using the helper function.
+
+```
+<?php
+$response = $api->query(
+    Predicates::at('document.id', 'WAjgAygAAN3B0a-a'),
+    [ 'lang' => '*' ]
+);
+$document = $response->results[0];
+// $document contains the document content
+```
+
+## Query multiple documents by IDs
+
+We've created a helper function that makes it easy to query multiple documents by IDs.
+
+### getByIDs helper function
+
+Here is an example of querying multiple documents by their ids using the `getByIDs` helper function.
+
+```
+<?php
+$ids = ['WAjgAygAAN3B0a-a', 'WC7GECUAAHBHQd-Y', 'WEE_gikAAC2feA-z'];
+$response = $api->getByIDs($ids);
+// $response contains the response object, $response->results holds the retrieved documents
+```
+
+### Without the helper function
+
+Here is an example of how to perform the same query as above, but this time without using the helper function.
+
+```
+<?php
+$ids = ['WAjgAygAAN3B0a-a', 'WC7GECUAAHBHQd-Y', 'WEE_gikAAC2feA-z'];
+$response = $api->query(
+    Predicates::in('document.id', $ids),
+    [ 'lang' => '*' ]
+);
+// $response contains the response object, $response->results holds the retrieved documents
+```
+
+## Query a document by its UID
+
+If you have added the UID field to a custom type, you can query a document by its UID.
+
+### getByUID helper function
+
+Here is an example showing how to query a document of the type "page" by its UID "about-us" using the `getByUID` helper function.
+
+```
+<?php
+$document = $api->getByUID('page', 'about-us');
+// $document contains the document content
+```
+
+### Query by language
+
+It's possible that you may have documents in different languages with the same UID value. In that case, you will need to specify the language code in order to retrieve the correct document.
+
+```
+<?php
+$options = [ 'lang' => 'fr-fr' ];
+$document = $api->getByUID('page', 'about-us', $options);
+// $document contains the fr-fr document content
+```
+
+> Note that if you don't specify the language or if you specify the wildcard value `'*'`, the oldest document with this UID value will be returned.
+
+### Query all language versions by UID
+
+The `getByUID` function will always return a single document. If you need to query all the language versions that share the same UID, then you can use the following method (without the helper function) to retrieve them all at the same time.
+
+### Without the helper function
+
+Here is an example of the same query without using the helper function. It will query the document(s) of the type "page" that contains the UID "about us".
+
+```
+<?php
+$response = $api->query(
+    Predicates::at('my.page.uid', 'about-us'),
+    [ 'lang' => '*' ]
+);
+// $response contains the response object
+```

--- a/docs/02-query-the-api/08-query-all-documents.md
+++ b/docs/02-query-the-api/08-query-all-documents.md
@@ -1,0 +1,23 @@
+# Query all your Documents
+
+If you need to query all of the documents in your repository, you can just run a query with an empty string.
+
+## Without query options
+
+Here is an example that will query your repository for all documents. By default, the API will paginate the results, with 20 documents per page.
+
+```
+<?php
+$response = $api->query('');
+// $response contains the response object, $response->results holds the retrieved documents
+```
+
+## With query options
+
+You can add options to this query. In the following example we allow 100 documents per page for the query response.
+
+```
+<?php
+$response = $api->query('', [ 'pageSize' => 100 ]);
+// $response contains the response object, $response->results holds the retrieved documents
+```

--- a/docs/02-query-the-api/09-query-by-type.md
+++ b/docs/02-query-the-api/09-query-by-type.md
@@ -1,0 +1,43 @@
+# Query by Type
+
+Here we discuss how to query all the documents of a certain custom type from your content repository.
+
+## By One Type
+
+### Example 1
+
+This first example shows how to query all of the documents of the custom type "blog-post". The option included in this query will sort the results by their "date" field (from most recent to the oldest).
+
+```
+<?php
+$response = $api->query(
+    Predicates::at('document.type', 'blog-post'),
+    [ 'orderings' => '[my.blog-post.date desc]' ]
+);
+// $response contains the response object, $response->results holds the retrieved documents
+```
+
+### Example 2
+
+The following example shows how to query all of the documents of the custom type "video-game". The options will make it so that the results are sorted alphabetically, limited to 10 games per page, and showing the second page of results.
+
+```
+<?php
+$response = $api->query(
+    Predicates::at('document.type', 'video-game'),
+    [ 'pageSize' => 10, 'page' => 2, 'orderings' => '[my.video-game.title]' ]
+);
+// $response contains the response object, $response->results holds the retrieved documents
+```
+
+## By Multiple Types
+
+This example shows how to query all of the documents of two different custom types: "article" and "blog_post".
+
+```
+<?php
+$response = $api->query(
+    Predicates::any('document.type', ['article', 'blog_post'])
+);
+// $response contains the response object, $response->results holds the retrieved documents
+```

--- a/docs/02-query-the-api/10-query-by-tag.md
+++ b/docs/02-query-the-api/10-query-by-tag.md
@@ -1,0 +1,27 @@
+# Query by Tag
+
+Here we show how to query all of the documents with a certain tag.
+
+## Query a single tag
+
+This example shows how to query all the documents with the tag "English".
+
+```
+<?php
+$response = $api->query(
+    Predicates::at('document.tags', ['English'])
+);
+// $response contains the response object, $response->results holds the retrieved documents
+```
+
+## Query multiple tags
+
+The following example shows how to query all of the documents with either the tag "Tag 1" or "Tag 2".
+
+```
+<?php
+$response = $api->query(
+    Predicates::any('document.tags', ['Tag 1', 'Tag 2'])
+);
+// $response contains the response object, $response->results holds the retrieved documents
+```

--- a/docs/02-query-the-api/11-query-by-date.md
+++ b/docs/02-query-the-api/11-query-by-date.md
@@ -1,0 +1,46 @@
+# Query by Date
+
+This page shows multiple ways to query documents based on a date field.
+
+Here we use a few predicates that can query based on Date or Timestamp fields. Feel free to explore the [Date & Time based Predicate Reference](../02-query-the-api/03-date-and-time-based-predicate-reference.md) page to learn more about this.
+
+## Query by an exact date
+
+The following is an example that shows how to query for all the documents of the type "article" with the release-date field ("date") equal to January 22, 2020. Note that this type of query will only work for the Date Field, not the Timestamp field.
+
+```
+<?php
+$response = $api->query(
+    Predicates::at('my.article.release-date', '2020-01-22')
+);
+// $response contains the response object, $response->results holds the retrieved documents
+```
+
+## Query by month and year
+
+Here is an example of a query for all documents of the type "blog-post" whose release-date is in the month of May in the year 2020. This might be useful for a blog archive.
+
+```
+<?php
+$response = $api->query(
+    [ Predicates::month('my.blog-post.release-date', 'May'),
+      Predicates::year('my.blog-post.release-date', 2020) ]
+);
+// $response contains the response object, $response->results holds the retrieved documents
+```
+
+## Query by publication date
+
+You can also query documents by their first or last publication dates.
+
+Here is an example of a query for all documents of the type "blog-post" whose original publication date is in the month of May in the year 2020.
+
+```
+<?php
+$response = $api->query(
+    [ Predicates::at('document.type', 'blog-post'),
+      Predicates::month('document.first_publication_date', 'May'),
+      Predicates::year('document.first_publication_date', 2020) ]
+);
+// $response contains the response object, $response->results holds the retrieved documents
+```

--- a/docs/02-query-the-api/12-query-by-a-field.md
+++ b/docs/02-query-the-api/12-query-by-a-field.md
@@ -1,0 +1,83 @@
+# Query by a Field
+
+There are a number of fields that you can query by. Here we give a examples that show how to query by the Boolean, Number, Key Text, Document Link, and Select fields.
+
+## Boolean Field
+
+The following example queries all the "post" custom type documents with the ** "**switch"\*\* **field equal to _true_ by using the** \*\*at predicate. It also sorts the results by their title.
+
+```
+<?php
+$response = $api->query(
+    Predicates::at('my.post.switch', true),
+    [ 'orderings' => '[my.post.title]' ]
+);
+// $response contains the response object, $response->results holds the retrieved documents
+```
+
+## Number field
+
+The following example shows how to query all the products with the "price" field (Number) less than 100.
+
+```
+<?php
+$response = $api->query(
+    Predicates::lt('my.product.price', 100)
+);
+// $response contains the response object, $response->results holds the retrieved documents
+```
+
+You can find more query predicates for Number fields on the [Query Predicate Reference](../02-query-the-api/02-query-predicate-reference.md) page.
+
+## Key Text field
+
+The following example shows how to query all the "employee" custom type documents with the "job-title" field (Key Text) equal to either "Developer" or "Designer".
+
+```
+<?php
+$response = $api->query(
+    Predicates::any('my.employee.job-title', ['Developer', 'Designer'])
+);
+// $response contains the response object, $response->results holds the retrieved documents
+```
+
+## Content Relationship / Document Link Field
+
+To query by a particular document link value, you must use the ID of the document you are looking for.
+
+The following example queries all the "blog_post" custom type documents with the "category_link" field (a Document Link) equal to the category with a document ID of "WNje3SUAAEGBu8bc".
+
+```
+<?php
+$response = $api->query(
+    [ Predicates::at('document.type', 'blog_post'),
+      Predicates::at('my.blog_post.category_link', 'WNje3SUAAEGBu8bc') ]
+);
+// $response contains the response object, $response->results holds the retrieved documents
+```
+
+## Select field
+
+The following demonstrates how to query all the "book" custom type documents with the "author" field (Select) equal to "John Doe". It also sorts the results by their titles.
+
+```
+<?php
+$response = $api->query(
+    Predicates::at('my.book.author', 'John Doe'),
+    [ 'orderings' => '[my.book.title]' ]
+);
+// $response contains the response object, $response->results holds the retrieved documents
+```
+
+## Select field within a Group
+
+It is also possible to query by a field inside of a group. The following queries all the "book" custom type documents with the "name" field (Select) equal to "John Doe". In this case the "name" field is in a group field named "author-info".
+
+```
+<?php
+$response = $api->query(
+    Predicates::at('my.book.author-info.name', 'John Doe'),
+    [ 'orderings' => '[my.book.title]' ]
+);
+// $response contains the response object, $response->results holds the retrieved documents
+```

--- a/docs/02-query-the-api/13-query-by-content-relationship.md
+++ b/docs/02-query-the-api/13-query-by-content-relationship.md
@@ -1,0 +1,35 @@
+# Query by Content Relationship Field
+
+To query by a particular Content Relationship / Document link value, you must use the ID of the document you are looking for.
+
+> **You must use the document ID**
+>
+> Note that you must use the document ID to make this query. It does not work if you try to query using a UID value.
+
+## By a Content Relationship field
+
+The following example queries all the "blog_post" custom type documents with the "category_link" field (a Content Relationship) equal to the category with a document ID of "WNje3SUAAEGBu8bc".
+
+```
+<?php
+$response = $api->query(
+    [ Predicates::at('document.type', 'blog_post'),
+      Predicates::at('my.blog_post.category_link', 'WNje3SUAAEGBu8bc') ]
+);
+// $response contains the response object, $response->results holds the retrieved documents
+```
+
+## By a Content Relationship field in a Group
+
+If your Content Relationship field is inside a group, you just need to specify the Group, then the Content Relationship field.
+
+Here is an example that queries all the "blog_post" custom type documents with the "category_link" field (a Content Relationship) equal to the category with a document ID of "WNje3SUAAEGBu8bc". In this case, the Content Relationship field is inside a Group field with the API ID of "categories".
+
+```
+<?php
+$response = $api->query(
+    [ Predicates::at('document.type', 'blog_post'),
+      Predicates::at('my.blog_post.categories.category_link', 'WNje3SUAAEGBu8bc') ]
+);
+// $response contains the response object, $response->results holds the retrieved documents
+```

--- a/docs/02-query-the-api/14-fulltext-search.md
+++ b/docs/02-query-the-api/14-fulltext-search.md
@@ -1,0 +1,28 @@
+# Fulltext Search with Laravel
+
+You can use the Fulltext predicate to search a document for a given term or terms.
+
+The `fulltext` predicate searches the term in any of the following fields:
+
+- Rich Text
+- Title
+- Key Text
+- UID
+- Select
+
+To learn more about this predicate checkout the [Query Predicate Reference](../02-query-the-api/02-query-predicate-reference.md) page.
+
+> Note that the fulltext search is not case sensitive.
+
+## Example Query
+
+This example shows how to query for all the documents of the custom type "blog-post" that contain the word "news".
+
+```
+<?php
+$response = $api->query(
+    [ Predicates::at('document.type', 'blog-post'),
+      Predicates::fulltext('document', 'news') ]
+);
+// $response contains the response object, $response->results holds the retrieved documents
+```

--- a/docs/02-query-the-api/15-use-multiple-predicates.md
+++ b/docs/02-query-the-api/15-use-multiple-predicates.md
@@ -1,0 +1,31 @@
+# Use Multiple Predicates
+
+You can combine multiple predicates in a single query, for example querying for a certain custom type with a given tag.
+
+You simply need to put all the predicates into a comma-separated array.
+
+## Example 1
+
+Here is an example that queries all of the documents of the custom type "blog-post" that have the tag "featured".
+
+```
+<?php
+$response = $api->query(
+    [ Predicates::at('document.type', 'blog-post'),
+      Predicates::at('document.tags', ['featured']) ]
+);
+// $response contains the response object, $response->results holds the retrieved documents
+```
+
+## Example 2
+
+Here is an example that queries all of the documents of the custom type "employee" excluding those with the tag "manager".
+
+```
+<?php
+$response = $api->query(
+    [ Predicates::at('document.type', 'employee'),
+      Predicates::not('document.tags', ['manager']) ]
+);
+// $response contains the response object, $response->results holds the retrieved documents
+```

--- a/docs/02-query-the-api/16-fetch-linked-items.md
+++ b/docs/02-query-the-api/16-fetch-linked-items.md
@@ -1,0 +1,73 @@
+# Fetch Linked Document Fields
+
+Here we explore an example that fetches a specific content field from a linked document.
+
+## The fetchLinks option
+
+The `fetchLinks` option allows you to retrieve a specific content field from a linked document and add it to the document response object.
+
+Note that this will only retrieve content of the following field types:
+
+- Color
+- Content Relationship
+- Date
+- Image
+- Key Text
+- Number
+- Rich Text (but only returns the first element)
+- Select
+- Timestamp
+
+It is **not** possible to retrieve the following content field types:
+
+- Embed
+- GeoPoint
+- Link
+- Link to Media
+- Rich Text (anything other than the first element)
+- Title
+- Any field in a Group or Slice
+
+The value you enter for the fetchLinks option needs to take the following format:
+
+```
+[ 'fetchLinks' => '{custom-type}.{field}' ]
+```
+
+| Property                            | Description                                                                  |
+| ----------------------------------- | ---------------------------------------------------------------------------- |
+| <strong>{custom-type}</strong><br/> | <p>The custom type API-ID of the linked document</p>                         |
+| <strong>{field}</strong><br/>       | <p>The API-ID of the field you wish to retrieve from the linked document</p> |
+
+## A simple example
+
+The following is an example that uses the *fetchLinks* option. We are querying for a "recipe" document with the uid "chocolate-chip-cookies".
+
+The "recipe" Custom Type has a Content Relationship (AKA Document Link) field with the API ID `author_link` which links to an "author" document.
+
+Inside the "author" document you have a Key Text field with the API ID `name`.
+
+The following will show you how to retrieve the author name field when querying the recipe.
+
+```
+$response = $api->query(
+    Predicates::at('my.recipe.uid', 'chocolate-chip-cookies'),
+    [ 'fetchLinks' => 'author.name' ]
+);
+
+$document = $response->results[0];
+
+$author = $document->data->author_link;
+// $author now works like a top-level document
+
+$authorName = $author->data->name;
+// $authorName contains the text from the "name" field
+```
+
+## Fetch multiple fields
+
+In order to fetch more than one field from the linked document, you just need to provide an array of fields. Here is an example that fetches the fields `name` and `picture` from the `author` custom type.
+
+```css
+[ 'fetchLinks' => 'author.name, author.picture' ]
+```

--- a/docs/02-query-the-api/17-order-your-results.md
+++ b/docs/02-query-the-api/17-order-your-results.md
@@ -1,0 +1,69 @@
+# Order your results
+
+This page shows how to order the results of your query for prismic.io. It explains how to use the orderings and after predicate options.
+
+## orderings
+
+The `orderings` option orders the results by the specified field(s). You can specify as many fields as you want.
+
+| Property                                | Description                                                                                    |
+| --------------------------------------- | ---------------------------------------------------------------------------------------------- |
+| <strong>lowest to highest</strong><br/> | <p>It will automatically order the field from lowest to highest</p>                            |
+| <strong>highest to lowest</strong><br/> | <p>Use &quot;desc&quot; next to the field name to instead order it from greatest to lowest</p> |
+
+```css
+[ 'orderings' => '[my.product.price]' ] // lowest to highest
+[ 'orderings' => '[my.product.price desc]' ] // highest to lowest
+```
+
+### Specifying multiple orderings
+
+You can specify more than one field to order your results by. To do so, simply add more than one field in the array.
+
+The results will be ordered by the first field in the array. If any of the results have the same value for that initial sort, they will then be sorted by the next specified field.
+
+Here is an example that first sorts the products by price from lowest to highest. If any of the products have the same price, then they will be sorted by their titles.
+
+```css
+[ 'orderings' => '[my.product.price, my.product.title]' ]
+```
+
+### Order by publication dates
+
+It is also possible to order documents by their first or last publication dates.
+
+The **first publication date** is the date that the document was originally published for the first time. The **last publication date** is the most recent date that the document has been published after editing.
+
+```javascript
+[ 'orderings' => '[document.first_publication_date]' ]
+[ 'orderings' => '[document.last_publication_date]' ]
+```
+
+## after
+
+The `after` option can be used along with the orderings option. It will remove all the documents except for those after the specified document in the list.
+
+To clarify, let’s say you have a query that return the following documents in this order:
+
+- `V9Zt3icAAAl8Uzob (Page 1)`
+- `PqZtvCcAALuRUzmO (Page 2)`
+- `VkRmhykAAFA6PoBj (Page 3)`
+- `V4Fs8rDbAAH9Pfow (Page 4)`
+- `G8ZtxQhAALuSix6R (Page 5)`
+- `Ww9yuAvdAhl87wh6 (Page 6)`
+
+If you add the `after` option and specify page 3, “`VkRmhykAAFA6PoBj`”, your query will return the following:
+
+- `V4Fs8rDbAAH9Pfow (Page 4)`
+- `G8ZtxQhAALuSix6R (Page 5)`
+- `Ww9yuAvdAhl87wh6 (Page 6)`
+
+By reversing the orderings in your query, you can use this same method to retrieve all the documents before the specified document.
+
+This option is useful when creating a navigation for a blog.
+
+Simply use the `after` parameter in your query options as shown below.
+
+```css
+[ 'after' => 'VkRmhykAAFA6PoBj' ]
+```

--- a/docs/02-query-the-api/18-pagination-for-results.md
+++ b/docs/02-query-the-api/18-pagination-for-results.md
@@ -1,0 +1,35 @@
+# Pagination for Results
+
+The results retrieved from the prismic.io repository will automatically be paginated. Here you will find an explanation for how to modify the pagination parameters.
+
+## pageSize
+
+The `pageSize` option defines the maximum number of documents that the API will return for your query. The default is 20, and the maximum is 100.
+
+Here is an example that shows how to query all of the documents of the custom type "recipe," allowing 100 documents per page.
+
+```
+<?php
+$response = $api->query(
+    Predicates::at('document.type', 'recipe'),
+    [ 'pageSize' => 100 ]
+);
+// $response contains the response object, $response->results holds the retrieved documents
+```
+
+## page
+
+The `page` option defines the pagination for the results of your query.
+
+If left unspecified, it will default to 1, which corresponds to the first page.
+
+Here is an example that show how to query all of the documents of the custom type "recipe". The options entered will limit the results to 50 recipes per page, and will display the third page of results.
+
+```
+<?php
+$response = $api->query(
+    Predicates::at('document.type', 'recipe'),
+    [ 'pageSize' => 50, 'page' => 3 ]
+);
+// $response contains the response object, $response->results holds the retrieved documents
+```

--- a/docs/02-query-the-api/19-query-by-language.md
+++ b/docs/02-query-the-api/19-query-by-language.md
@@ -1,0 +1,39 @@
+# Query by Language
+
+When querying the API, you can query by language.
+
+## Query a specific language
+
+You simply need to add the `lang` query option and set it to the language code you are querying (example, "en-us" for American English).
+
+> If you don't specify a `lang` the query will automatically query the documents in your master language.
+
+Here is an example of how to query for all the documents of the type "blog-post" in French (language code "fr-fr").
+
+```
+<?php
+$response = $api->query(
+    Predicates::at('document.type', 'blog-post'),
+    [ 'lang' => 'fr-fr' ]
+);
+// $response contains the response object, $response->results holds the retrieved documents
+```
+
+## Query for all languages
+
+If you want to query all the document in all languages you can add the wildcard, `'*'`, as your lang option.
+
+This example shows this by querying all documents of the type "blog-post" in all languages.
+
+```
+<?php
+$response = $api->query(
+    Predicates::at('document.type', 'blog-post'),
+    [ 'lang' => '*' ]
+);
+// $response contains the response object, $response->results holds the retrieved documents
+```
+
+## Query by UID & language
+
+To learn more about how to query your documents by UID and language, check out the [Query by ID and UID](../02-query-the-api/07-query-by-id-or-uid.md) page.

--- a/docs/03-templating/01-the-response-object.md
+++ b/docs/03-templating/01-the-response-object.md
@@ -1,0 +1,92 @@
+# The Response Object
+
+Once you have set up your Custom Types and queried your content from the API, it’s time to integrate that content into your templates.
+
+First we’ll go over the response object returned from the API, then we’ll discuss how to retrieve your content.
+
+## An example response
+
+Let’s start by taking a look at the Response Object returned when querying the API. Here is a simple example of response object with one document that contains a couple of fields.
+
+```
+{
+  "page": 1,
+  "results_per_page": 20,
+  "results_size": 1,
+  "total_results_size": 1,
+  "total_pages": 1,
+  "next_page": null,
+  "prev_page": null,
+  "results": [
+    {
+      "id": "WKxlPCUEEIZ10AHU",
+      "uid": "example-page",
+      "type": "page",
+      "href": "https://your-repo-name.prismic.io/api/v2/documents/search...",
+      "tags": [],
+      "first_publication_date": "2017-01-13T11:45:21.000Z",
+      "last_publication_date": "2017-02-21T16:05:19.000Z",
+      "slugs": [
+        "example-page"
+      ],
+      "linked_documents": [],
+      "lang": "en-us",
+      "alternate_languages": [
+        {
+          "id": "WZcAEyoAACcA0LHi",
+          "uid": "example-page-french",
+          "type": "page",
+          "lang": "fr-fr"
+         }
+      ],
+      "data": {
+        "title": [
+          {
+            "type": "heading1",
+            "text": "Example Page",
+            "spans": []
+          }
+        ],
+        "date": "2017-01-13"
+      }
+    }
+  ]
+}
+```
+
+At the topmost level of the response object, you mostly have information about the number of results returned from the query and the pagination of the results.
+
+| Property                                 | Description                                                                           |
+| ---------------------------------------- | ------------------------------------------------------------------------------------- |
+| <strong>page</strong><br/>               | <p>The current page of the pagination of the results</p>                              |
+| <strong>results_per_page</strong><br/>   | <p>The number of documents per page of the pagination</p>                             |
+| <strong>results_size</strong><br/>       | <p>The number of documents on this page of the pagination results</p>                 |
+| <strong>total_results_size</strong><br/> | <p>The total number of documents returned from the query</p>                          |
+| <strong>total_pages</strong><br/>        | <p>The total number of pages in the pagination of the results</p>                     |
+| <strong>next_page</strong><br/>          | <p>The next page number in the pagination</p>                                         |
+| <strong>prev_page</strong><br/>          | <p>The previous page number in the pagination</p>                                     |
+| <strong>results</strong><br/>            | <p>The documents and their content for this page of the pagination of the results</p> |
+
+> Note that when using certain helper functions such as getSingle(), getByUID(), or getByID(), the first document of the results array will automatically be returned.
+
+## The Query Results
+
+The actual content of the returned documents can be found under "results". This will always be an array of the documents, even if there is only one document returned.
+
+Let’s say that you saved your response object in a variable named `$response`. This would mean that your documents could be accessed with the following:
+
+```
+<?php
+$documents = $response->results;
+```
+
+And if you only returned one document, it would be accessed with the following:
+
+```
+<?php
+$document = $response->results[0];
+```
+
+> Note: As mentioned above, this is not the case when using certain helper functions such as getSingle(), getByUID(), or getByID(). These will automatically return the first document of the results array.
+
+Each document in the results array will contain information such as its document ID, uid, type, tags, slugs, first publication date, & last publication date. The content for each document will be found inside the "data" property.

--- a/docs/03-templating/02-the-document-object.md
+++ b/docs/03-templating/02-the-document-object.md
@@ -1,0 +1,116 @@
+# The Document Object
+
+Here we breakdown the document object returned from the Prismic API when developing with a Laravel project.
+
+> **Before Reading**
+>
+> This article assumes that you have queried your API and saved the document object in a variable named `$document`.
+
+## An example response
+
+Let's start by taking a look at the Document Object returned when querying the API. Here is a simple example of a document that contains a couple of fields.
+
+```json
+{
+  "id": "WKxlPCUEEIZ10AHU",
+  "uid": "example-page",
+  "type": "page",
+  "href": "https://your-repo-name.prismic.io/api/v2/documents/search...",
+  "tags": ["Tag 1", "Tag 2"],
+  "first_publication_date": "2017-01-13T11:45:21.000Z",
+  "last_publication_date": "2017-02-21T16:05:19.000Z",
+  "slugs": ["example-page"],
+  "linked_documents": [],
+  "lang": "en-us",
+  "alternate_languages": [
+    {
+      "id": "WZcAEyoAACcA0LHi",
+      "uid": "example-page-french",
+      "type": "page",
+      "lang": "fr-fr"
+    }
+  ],
+  "data": {
+    "title": [
+      {
+        "type": "heading1",
+        "text": "Example Page",
+        "spans": []
+      }
+    ],
+    "date": "2017-01-13"
+  }
+}
+```
+
+## Accessing Document Fields
+
+Here is how to access each document field.
+
+### ID
+
+```bash
+$document->id
+```
+
+### UID
+
+```bash
+$document->uid
+```
+
+### Type
+
+```bash
+$document->type
+```
+
+### API Url
+
+```bash
+$document->href
+```
+
+### Tags
+
+```bash
+$document->tags
+// returns an array
+```
+
+### First Publication Date
+
+```bash
+$document->first_publication_date
+```
+
+### Last Publication Date
+
+```bash
+$document->last_publication_date
+```
+
+### Language
+
+```bash
+$document->lang
+```
+
+### Alternate Language Versions
+
+```bash
+$document->alternate_languages
+// returns an array
+```
+
+You can read more about this in the [Multi-language Templating](../03-templating/12-multi-language-info.md) page.
+
+## Document Content
+
+To retrieve the content fields from the document you must specify the API ID of the field. Here is an example that retrieves a Date field's content from the document. Here the Date field has the API ID of `date`.
+
+```bash
+$document->data->date
+```
+
+Refer to the specific templating documentation for each field to learn how to add content fields to your pages.

--- a/docs/03-templating/03-boolean.md
+++ b/docs/03-templating/03-boolean.md
@@ -1,0 +1,14 @@
+# Templating the Boolean Field
+
+The Boolean field will add a switch for a true or false values for the content authors to pick from.
+
+## Get the boolean value
+
+Here is an example of how to retrieve the value from a Boolean field which has the API ID switch.
+
+```
+@php
+$example = $document->data->switch
+if ($example) echo 'This is printed if value is true.<br />';
+@endphp
+```

--- a/docs/03-templating/04-color.md
+++ b/docs/03-templating/04-color.md
@@ -1,0 +1,15 @@
+# Templating the Color Field
+
+The Color field allows content writers to select a color through a color picker or to manually write a hexadecimal value.
+
+## Get the color value
+
+Color value is a string representing a color in hexadecimal format such as "#1e89ce".
+
+Here is an example of how to retrieve the value from a Color field. In this case, the API ID of the field is `color`.
+
+```
+<h2 style="color: {{ $document->data->color }};">Colorful Title</h2>
+// Outputs:
+<h2 style="color: #1e89ce;">Colorful Title</h2>
+```

--- a/docs/03-templating/05-date.md
+++ b/docs/03-templating/05-date.md
@@ -1,0 +1,27 @@
+# Templating the Date field
+
+The Date field allows content writers to add a date that represents a calendar day.
+
+## Get the date value
+
+Date value is a string formatted as YYYY-MM-DD (example: 2020-02-19).
+
+Here is an example that retrieves the value of a Date field with the API ID of `date`.
+
+```html
+<time>{{ $document->data->date }}</time> // Outputs: 2020-02-19
+```
+
+## Format the Date
+
+You can also customize the output of the Date field.
+
+```
+@php
+    use Prismic\Dom\Date;
+    $date = Date::asDate($document->data->date);
+@endphp
+
+<time>{{ $date->format('l M jS, Y') }}</time>
+// Outputs: Sunday Feb 19th, 2020
+```

--- a/docs/03-templating/06-embed.md
+++ b/docs/03-templating/06-embed.md
@@ -1,0 +1,11 @@
+# Templating the Embed field
+
+The Embed field will let content writers paste an oEmbed supported service resource URL (YouTube, Vimeo, Soundcloud, etc.), and add the embedded content to your website.
+
+## Display as HTML
+
+Here's an example of how to integrate the Embed field into your templates. In this case the Embed field has an API ID of `video`.
+
+```html
+<div>{!! $document->data->video->html !!}</div>
+```

--- a/docs/03-templating/07-geopoint.md
+++ b/docs/03-templating/07-geopoint.md
@@ -1,0 +1,17 @@
+# Templating the GeoPoint field
+
+The GeoPoint field is used for Geolocation coordinates. It works by adding coordinates or by pasting a Google Maps URL.
+
+## Get the latitude and longitude
+
+Here's an example of how to integrate the GeoPoint field into your templates. In this case the GeoPoint field has the API ID of `location`.
+
+```
+@php
+    $latitude = $document->data->location->latitude;
+    $longitude = $document->data->location->longitude;
+@endphp
+
+<p>Location: {{ $latitude . ', ' . $longitude }}</p>
+// Outputs: Location: 48.880401900547, 2.3423677682877
+```

--- a/docs/03-templating/08-group.md
+++ b/docs/03-templating/08-group.md
@@ -1,0 +1,72 @@
+# Templating the Group Field
+
+The Group field is used to create a repeatable collection of fields.
+
+## Repeatable Group
+
+### Looping through the Group content
+
+Here's how to integrate a repeatable Group field into your templates. First get the group which is an array. Then loop through each item in the group as shown in the following example.
+
+This example uses a Group field with an API ID of `references`. The group field consists of a Link field with an API ID of `link` and a Rich Text field with the API ID of `label`.
+
+```
+@php
+    use Prismic\Dom\Link;
+    use Prismic\Dom\RichText;
+@endphp
+
+<ul>
+    @foreach ($document->data->references as $item)
+        <li>
+            <a href="{{ Link::asUrl($item->link) }}">
+                {{ RichText::asText($item->label) }}
+            </a>
+        </li>
+    @endforeach
+</ul>
+```
+
+### Example 2
+
+Here's another example that shows how to integrate a group of images (e.g. a photo gallery) into a page.
+
+This example has a Group field with the API ID of `photo_gallery`. The group contains an Image field with the API ID of `photo` and a Rich Text field with the API ID of `caption`.
+
+```
+@php
+    use Prismic\Dom\RichText;
+@endphp
+
+@foreach ($document->data->photo_gallery as $item)
+    <figure>
+        <img src="{{ $item->photo->url }}" alt="{{ $item->photo->alt }}" />
+        <figcaption>{{ RichText::asText($item->caption) }}</figcaption>
+    </figure>
+@endforeach
+```
+
+## Non-repeatable Group
+
+Even if the group is non-repeatable, the Group field will be an array. You simply need to get the first (and only) group in the array and you can retrieve the fields in the group like any other.
+
+Here is an example showing how to integrate the fields of a non-repeatable Group into your templates. In this case the Group field has an API ID of `banner_group`. The group consists of an Image field `banner_image`, a Rich Text field `banner_desc`, a Link field `banner_link`, and a Rich Text field `banner_link_label`.
+
+```
+@php
+    use Prismic\Dom\RichText;
+    use Prismic\Dom\Link;
+
+    $bannerGroup = $document->data->banner_group[0];
+    $bannerImage = $bannerGroup->banner_image;
+    $bannerDesc = RichText::asHtml($bannerGroup->banner_desc);
+    $bannerLinkUrl = Link::asUrl($bannerGroup->banner_link);
+    $bannerLinkLabel = RichText::asText($bannerGroup->banner_link_label);
+@endphp
+
+<div class="banner">
+    <img class="banner-image" src="{{ $bannerImage->url }}" alt="{{ $bannerImage->alt }}" />
+    <p class="banner-desc">{!! $bannerDesc !!}</p>
+    <a class="banner-link" href="{{ $bannerLinkUrl }}">{{ $bannerLinkLabel }}</a>
+</div>
+```

--- a/docs/03-templating/09-images.md
+++ b/docs/03-templating/09-images.md
@@ -1,0 +1,71 @@
+# Templating the Image field
+
+The Image field allows content writers to upload an image that can be configured with size constraints and responsive image views.
+
+## Output an image in your template
+
+Here's an example of integrating an image. In this case the Image field has the API ID of `illustration`.
+
+```
+<img
+    src="{{ $document->data->illustration->url }}"
+    alt="{{ $document->data->illustration->alt }}"
+/>
+```
+
+> Note that the `alt` attribute is mandatory in HTML5 for image element. We advise to always write an alternative text for each image uploaded to your Prismic's media library.
+
+Here's an example of integrating an illustration with a caption. In this case we have an Image field with the API ID of `illustration` and a Rich Text field with an API ID of `caption`.
+
+```html
+@php use Prismic\Dom\RichText; @endphp
+
+<figure>
+  <img
+    src="{{ $document->data->illustration->url }}"
+    alt="{{ $document->data->illustration->alt }}"
+  />
+  <figcaption>{{ RichText::asText($document->data->caption) }}</figcaption>
+</figure>
+```
+
+## Get a responsive image view
+
+Here is how to add responsive images using the HTML picture element. In this example we have an Image field with the API ID of `responsive_image`. This Image field has the default image view along with views named `tablet` and `mobile`.
+
+```
+@php
+    $mainView = $document->data->responsive_image;
+    $tabletView = $document->data->responsive_image->tablet;
+    $mobileView = $document->data->responsive_image->mobile;
+@endphp
+
+<picture>
+    <source media="(max-width: 400px)", srcset="{{ $mobileView->url }}" /> 
+    <source media="(max-width: 900px)", srcset="{{ $tabletView->url }}" /> 
+    <source srcset="{{ $mainView->url }}" />
+    <image src="{{ $mainView->url }}" alt="{{ $mainView->alt }}" />
+</picture>
+```
+
+## Get the image width & height
+
+You can retrieve the main image's width or height. In this example we have an Image field with the API ID of `featured_image`.
+
+```java
+@php
+    $width = $document->data->featured_image->dimensions->width;
+    $height = $document->data->featured_image->dimensions->height;
+@endphp
+```
+
+Here is how to retrieve the alt, width, and height value for a responsive image view. In this case the Image field has the API ID of `featured_image`.
+
+```java
+@php
+    $mobileView = $document->data->featured_image->mobile;
+    $alt = $mobileView->alt;
+    $width = $mobileView->dimensions->width;
+    $height = $mobileView->dimensions->height;
+@endphp
+```

--- a/docs/03-templating/10-key-text.md
+++ b/docs/03-templating/10-key-text.md
@@ -1,0 +1,11 @@
+# Templating the Key Text Field
+
+The Key Text field allows content writers to enter a single string.
+
+## Get the Key Text value
+
+Here is an example that shows how to get the value of a Key Text field. In this case, the Key Text field has the API ID of `title`.
+
+```html
+<h1>{{ $document->data->title }}</h1>
+```

--- a/docs/03-templating/11-links-and-content-relationship.md
+++ b/docs/03-templating/11-links-and-content-relationship.md
@@ -1,0 +1,33 @@
+# Templating Link & Content Relationship fields
+
+The Link field is used for adding links to the Web, to files in your prismic.io media library, or to documents in your prismic.io repository. The Content Relationship field is a Link field specifically used to link to a Document.
+
+> **Before Reading**
+>
+> This page assumes that you have retrieved your content and stored it in a variable named `$document`.
+>
+> It is also assumed that you have set up a Link Resolver stored in the variable `$linkResolver`. When integrating a Link in your templates, a link resolver might be necessary as shown & discussed below. To learn more about this, check out our [Link Resolving](../04-beyond-the-api/01-link-resolving.md) page.
+
+## Adding a hyperlink
+
+Here's the basic integration of a Link or Content Relationship. This will work for any kind of link: Link to the Web, Link to a Media Item, or a Link to a Document / Content Relationship.
+
+In this example, the Link field has an API ID of `my_link`.
+
+```
+@php
+    use Prismic\Dom\Link;
+
+    $link = $document->data->my_link;
+    $linkUrl = Link::asUrl($link, $linkResolver);
+    $targetAttr = property_exists($link, 'target') ? 'target="' . $link->target . '" rel="noopener"' : '';
+@endphp
+
+<a href="{{ $linkUrl }}" {{ $targetAttr }}>Click here</a>
+```
+
+## Using a Link Resolver
+
+Note that the example above uses a Link Resolver to output the link. This is only required for a Link to a Document / Content Relationship.
+
+If you know that your link will always be to Media Item or to the Web, then you can remove this. If the link is to or might be to a Document, then you should always use the Link Resolver.

--- a/docs/03-templating/12-multi-language-info.md
+++ b/docs/03-templating/12-multi-language-info.md
@@ -1,0 +1,47 @@
+# Templating Multi-language Info
+
+This page shows you how to access the language code and alternate language versions of a document.
+
+## Get the document language code
+
+You can get the language code of a document by accessing its `lang` property. This might give "en-us" (American english) or "fr-fr" (french) for example.
+
+```
+<?php
+$lang = $document->lang;
+```
+
+## Get the alternate language versions
+
+Next we will access the information about a document's alternate language versions.
+
+You can get the alternate languages using the `alternate_languages` property. Then simply loop through the array and access the ID, UID, type and language code of each as shown below.
+
+```
+<?php
+$altLangs = $document->alternate_languages;
+foreach ($altLangs as $altLang) {
+    $id = $altLang->id;
+    $uid = $altLang->uid;
+    $type = $altLang->type;
+    $lang = $altLang->lang;
+}
+```
+
+## Get a specific language version
+
+If you need to get a specific alternate language version, use the `getAlternateLanguage` helper method.
+
+Here's an example of how to get the french version ('fr-fr') of a document.
+
+```
+<?php
+use Prismic\Document;
+
+$frenchVersion = Document::getAlternateLanguage($document, 'fr-fr');
+
+$id = $frenchVersion->id;
+$uid = $frenchVersion->uid;
+$type = $frenchVersion->type;
+$lang = $frenchVersion->lang;
+```

--- a/docs/03-templating/13-number.md
+++ b/docs/03-templating/13-number.md
@@ -1,0 +1,11 @@
+# Templating the Number Field
+
+The Number field allows content writers to enter or select a number. You can set max and min values for the number.
+
+## Get the number value
+
+Here is an example of how to integrate a Number field into your template. In this case the Number field has the API ID of `price`.
+
+```html
+<div>{{ $document->data->price }}</div>
+```

--- a/docs/03-templating/14-rich-text-and-title.md
+++ b/docs/03-templating/14-rich-text-and-title.md
@@ -1,0 +1,89 @@
+# Templating the Rich Text & Title fields
+
+The Rich Text field (previously called Structured Text) is a configurable text field with formatting options. This field provides content writers with a WYSIWYG editor where they can define the text as a header or paragraph, make it bold, add links, etc. The Title field is a specific Rich Text field used for titles (HTML elements h1, h2, h3, h4, h5 and h6).
+
+> **Before Reading**
+>
+> This page assumes that you have retrieved your content and stored it in a variable named `$document`.
+>
+> It is also assumed that you have set up a Link Resolver stored in the variable `$linkResolver`. When integrating a Link in your templates, a link resolver might be necessary as shown & discussed below. To learn more about this, check out our [Link Resolving](../04-beyond-the-api/01-link-resolving.md) page.
+
+## Output as HTML
+
+The basic usage of the Rich Text / Title field is to use the `asHtml` helper method to transform the field into HTML.
+
+The following is an example that will display a section title. In this case, the Rich Text / Title field has the API ID of `title`.
+
+```
+@php
+    use Prismic\Dom\RichText;
+
+    $title = $document->data->title;
+    $titleHtml = RichText::asHtml($title, $linkResolver);
+@endphp
+
+<section>
+    {!! $titleHtml !!}
+</section>
+```
+
+In the previous example when calling the `asHtml` method, you need to pass in a Link Resolver function. This is needed if your content contains any links to documents in your repository. To learn more about how to set up a Link Resolver, check out our [Link Resolving](../04-beyond-the-api/01-link-resolving.md) page.
+
+### Example 2
+
+The following example shows how to display the rich text content of a blog post. In this case, the Rich Text field has the API ID of `blog_post`.
+
+```
+@php
+    use Prismic\Dom\RichText;
+@endphp
+
+<div class="blog-post-content">
+    {!! $RichText::asHtml($document->data->blog_post, $linkResolver) !!}
+</div>
+```
+
+### Changing the HTML Output
+
+You can customize the HTML output by passing an HTML serializer to the method. You can learn more about this on the [HTML Serializer](../04-beyond-the-api/03-html-serializer.md) page.
+
+Here is an example of an HTML serializer function that doesn't wrap images in a paragraph element and replaces all <em> elements with a <span> element with a custom CSS class.
+
+```
+@php
+    use Prismic\Dom\RichText;
+
+    $htmlSerializer = function ($element, $content) use ($linkResolver) {
+        // Don't wrap images in a <p> tag
+        if ($element->type === 'image') {
+            return '<img src="' . $element->url . '" alt="' . $element->alt . '">';
+        }
+        // Use a span element with a class instead of an em element
+        if ($element->type === 'em') {
+            return '<span class="some-class">' . $content . '</span>';
+        }
+        // Return null to stick with the default behavior for anything else
+        return null;
+    };
+@endphp
+
+<div class="blog-post-content">
+    {!! RichText::asHtml($document->data->blog_post, $linkResolver, $htmlSerializer) !!}
+</div>
+```
+
+## Output as plain text
+
+The `asText` helper method will convert and output the text in the Rich Text / Title field into a string without HTML elements.
+
+Here is an example of this where the Rich Text / Title field has the API ID of `author`.
+
+```
+@php
+    use Prismic\Dom\RichText;
+@endphp
+
+<h3 class="author">
+    {{ RichText::asText($document->data->author) }}
+</h3>
+```

--- a/docs/03-templating/15-select.md
+++ b/docs/03-templating/15-select.md
@@ -1,0 +1,11 @@
+# Templating the Select Field
+
+The Select field will add a dropdown select box of choices for the content writers to pick from.
+
+## Get the Select field value
+
+Here's an example of how to integrate the selected text value. In this case the Select field has the API ID of `category`.
+
+```html
+<p>{{ $document->data->category }}</p>
+```

--- a/docs/03-templating/16-slices.md
+++ b/docs/03-templating/16-slices.md
@@ -1,0 +1,153 @@
+# Templating Slices
+
+The Slices field is used to define a dynamic zone for richer page layouts.
+
+> **Before Reading**
+>
+> This page assumes that you have retrieved your content and stored it in a variable named `$document`.
+>
+> It is also assumed that you have set up a Link Resolver stored in the variable `$linkResolver`. When integrating a Link in your templates, a link resolver might be necessary as shown & discussed below. To learn more about this, check out our [Link Resolving](../04-beyond-the-api/01-link-resolving.md) page.
+
+## Example 1
+
+You can retrieve Slices from your documents by accessing the data property containing the slices zone, named by default `body`.
+
+Here is a simple example that shows how to add slices to your templates. In this example, we have two slice options: a text slice and an image gallery slice.
+
+### Text slice
+
+The "text" slice is simple and only contains one field, which is non-repeatable.
+
+| Property                                                 | Description                                                         |
+| -------------------------------------------------------- | ------------------------------------------------------------------- |
+| <strong>Primary</strong><br/><code>non-repeatable</code> | <p>- A Rich Text field with the API ID of &quot;rich_text&quot;</p> |
+| <strong>Items</strong><br/><code>repeatable</code>       | <p>None</p>                                                         |
+
+### Image gallery slice
+
+The "image_gallery" slice contains both a repeatable and non-repeatable field.
+
+| Property                                                 | Description                                                          |
+| -------------------------------------------------------- | -------------------------------------------------------------------- |
+| <strong>Primary</strong><br/><code>non-repeatable</code> | <p>- A Title field with the API ID of &quot;gallery_title&quot;</p>  |
+| <strong>Items</strong><br/><code>repeatable</code>       | <p>- An Image field with the API ID of &quot;gallery_image&quot;</p> |
+
+### Integration
+
+Here is an example of how to integrate these slices into a blog post.
+
+```
+@php
+    use Prismic\Dom\RichText;
+
+    $slices = $document->data->body;
+@endphp
+
+<div class="blog-content">
+    @foreach ($slices as $slice)
+        @switch ($slice->slice_type)
+            @case ('text')
+                {!! RichText::asHtml($slice->primary->rich_text, $linkResolver) !!}
+                @break
+            @case ('image_gallery')
+                {!! '<h2 class="gallery-title">' . RichText::asText($slice->primary->gallery_title) . '</h2>' !!}
+                @foreach ($slice->items as $item)
+                    {!! '<img src="' . $item->gallery_image->url . '" alt="' . $item->gallery_image->alt . '" />' !!}
+                @endforeach
+                @break
+            @endswitch
+    @endforeach
+</div>
+```
+
+## Example 2
+
+The following is a more advanced example that shows how to use Slices for a landing page. In this example, the Slice choices are FAQ question/answers, featured items, and text sections.
+
+### FAQ slice
+
+The "faq" slice takes advantage of both the repeatable and non-repeatable slice sections.
+
+| Property                                                 | Description                                                                                                                    |
+| -------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------ |
+| <strong>Primary</strong><br/><code>non-repeatable</code> | <p>- A Title field with the API ID of &quot;faq_title&quot;</p>                                                                |
+| <strong>Items</strong><br/><code>repeatable</code>       | <p>- A Title field with the API ID of &quot;question&quot;</p><p>- A Rich Text field with the API ID of &quot;answer&quot;</p> |
+
+### Featured Items slice
+
+The "featured_items" slice contains a repeatable set of an image, title, and summary fields.
+
+| Property                                                 | Description                                                                                                                                                                              |
+| -------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| <strong>Primary</strong><br/><code>non-repeatable</code> | <p>None</p>                                                                                                                                                                              |
+| <strong>Items</strong><br/><code>repeatable</code>       | <p>- An Image field with the API ID of &quot;image&quot;</p><p>- A Title field with the API ID of &quot;title&quot;</p><p>- A Rich Text field with the API ID of &quot;summary&quot;</p> |
+
+### Text slice
+
+The "text" slice contains only a Rich Text field in the non-repeatable section.
+
+| Property                                                 | Description                                                         |
+| -------------------------------------------------------- | ------------------------------------------------------------------- |
+| <strong>Primary</strong><br/><code>non-repeatable</code> | <p>- A Rich Text field with the API ID of &quot;rich_text&quot;</p> |
+| <strong>Items</strong><br/><code>repeatable</code>       | <p>None</p>                                                         |
+
+### Integration
+
+Here is an example of how to integrate these slices into a landing page.
+
+```
+@php
+    use Prismic\Dom\RichText;
+
+    $returnFaqSlice = function ($slice) use ($linkResolver) {
+        $html = '<div class="slice-faq">'
+            . RichText::asHtml($slice->primary->faq_title, $linkResolver);
+        foreach ($slice->items as $item) {
+            $html .= '<div>'
+                . RichText::asHtml($item->question, $linkResolver)
+                . RichText::asHtml($item->answer, $linkResolver)
+                . '</div>';
+        }
+        $html .= '</div>';
+        return $html;
+    };
+
+    $returnFeaturedItemsSlice = function ($slice) use ($linkResolver) {
+        $html = '<div class="slice-featured-items">';
+        foreach ($slice->items as $item) {
+            $html .= '<div>'
+                . '<img src="' . $item->image->url . '" alt="' . $item->image->alt . '" />'
+                . RichText::asHtml($item->title, $linkResolver)
+                . RichText::asHtml($item->summary, $linkResolver)
+                . '</div>';
+        }
+        $html .= '</div>';
+        return $html;
+    };
+
+    $returnTextSlice = function ($slice) use ($linkResolver) {
+        $html = '<div class="slice-text">'
+            . RichText::asHtml($slice->primary->rich_text, $linkResolver)
+            . '</div>';
+        return $html;
+    };
+
+    $slices = $document->data->body;
+@endphp
+
+<div class="page-content">
+    @foreach ($slices as $slice)
+        @switch ($slice->slice_type)
+            @case ('faq')
+                {!! $returnFaqSlice($slice) !!}
+                @break
+            @case ('featured_items')
+                {!! $returnFeaturedItemsSlice($slice) !!}
+                @break
+            @case ('text')
+                {!! $returnTextSlice($slice) !!}
+                @break
+        @endswitch
+    @endforeach
+</div>
+```

--- a/docs/03-templating/17-timestamp.md
+++ b/docs/03-templating/17-timestamp.md
@@ -1,0 +1,31 @@
+# Templating the Timestamp field
+
+The Timestamp field allows content writers to add a date and time.
+
+## Get the Timestamp value
+
+Timestamp value is a string format as YYYY-MM-DDTHH:MM:SS+0000<br/>(example: 2017-02-17T15:45:00+0000).
+
+Here is an example that retrieves the value of a Timestamp field with the API ID of `timestamp`.
+
+```
+<time>{{ $document->data->timestamp }}</time>
+// Outputs: 2017-02-17T15:45:00+0000
+```
+
+## Format the Timestamp
+
+You can also output the Timestamp in custom formats.
+
+Here is an example that outputs a custom format for a Timestamp field with the API ID of `date_and_time`.
+
+```
+@php
+    use Prismic\Dom\Date;
+
+    $timestamp = Date::asDate($document->data->date_and_time);
+@endphp
+
+<time>{{ $timestamp->format('H:i:s - d/m/Y') }}</time>
+// Outputs: 15:45:00 - 17/02/2017
+```

--- a/docs/03-templating/18-uid.md
+++ b/docs/03-templating/18-uid.md
@@ -1,0 +1,13 @@
+# Templating the UID field
+
+The UID field is a unique identifier that can be used specifically to create SEO-friendly website URLs.
+
+## Get the UID value
+
+To get the UID value, you just need to access UID property on the retrieved document object as shown below.
+
+```java
+@php
+   $uid = $document->uid;
+@endphp
+```

--- a/docs/04-beyond-the-api/01-link-resolving.md
+++ b/docs/04-beyond-the-api/01-link-resolving.md
@@ -1,0 +1,59 @@
+# Link Resolver
+
+When working with fields type such as Link or Structured Text, the prismic.io kit will need to generate links to documents within your website.
+
+## Define your internal routes
+
+Since routing is specific to your site, you will need to define it and provide it to some of the methods used on the fields.
+
+A Link Resolver is provided in every starter kit, but you may need to adapt it or write your own if you're using a different framework.
+
+## An example
+
+Here is an example of a Link Resolver for a Laravel blog site.
+
+```
+@php
+    use Prismic\LinkResolver;
+    use Prismic\Dom\RichText;
+    use Prismic\Dom\Link;
+
+    class ExampleLinkResolver extends LinkResolver
+    {
+        public function resolve($link) :? string
+        {
+            if (property_exists($link, 'isBroken') && $link->isBroken === true) {
+                return '/404';
+            }
+            if ($link->type === 'category') {
+                return '/category/' . $link->uid;
+            }
+            if ($link->type === 'post') {
+                return '/post/' . $link->uid;
+            }
+            return '/';
+        }
+    }
+
+    $linkResolver = new ExampleLinkResolver();
+@endphp
+
+<div class="blog-post-content">
+    {!! RichText::asHtml($document->data->blog_post, $linkResolver) !!}
+</div>
+
+<a href="{{ Link::asUrl($document->data->link, $linkResolver) }}">Click here</a>
+```
+
+## Accessible attributes
+
+When creating your Link Resolver function when using the API v2, you will have access to certain attributes of the linked document:
+
+| Property                                                     | Description                                             |
+| ------------------------------------------------------------ | ------------------------------------------------------- |
+| <strong>$link-&gt;id</strong><br/><code>string</code>        | <p>The document id</p>                                  |
+| <strong>$link-&gt;uid</strong><br/><code>string</code>       | <p>The user-friendly unique id</p>                      |
+| <strong>$link-&gt;type</strong><br/><code>string</code>      | <p>The custom type of the document</p>                  |
+| <strong>$link-&gt;tags</strong><br/><code>array</code>       | <p>Array of the document tags</p>                       |
+| <strong>$link-&gt;lang</strong><br/><code>string</code>      | <p>The language code of the document</p>                |
+| <strong>$link-&gt;isBroken</strong><br/><code>boolean</code> | <p>Boolean that states if the link is broken or not</p> |

--- a/docs/04-beyond-the-api/02-previews-and-the-prismic-toolbar.md
+++ b/docs/04-beyond-the-api/02-previews-and-the-prismic-toolbar.md
@@ -1,0 +1,132 @@
+# Previews and the Prismic Toolbar
+
+When working in the writing room, you can preview new content on your website without having to publish the document, you can set up one or more websites where the content can be previewed. This allows you to have a production server, staging server, development server, etc.  Discover how to [handle multiple environments in Prismic](https://intercom.help/prismicio/prismic-io-basics/using-multiple-environments-of-one-prismic-repository).<br/>
+The Toolbar allows you to edit your pages. In your website, just click the button, select the part of the page that they want to edit, and you'll be redirected to the appropriate page in the Writing Room.
+
+> **New Toolbar Activation for Older Repos**
+>
+> The current preview toolbar is enabled by default on all new Prismic repos. However, if you're on an older repo, you might be on older version of the toolbar. If your preview script `src` url includes `new=true`, then your preview functionality includes an edit button. If the `src` does not include `new=true` and you would like the new preview toolbar, please [contact us via the Prismic forum](https://community.prismic.io/t/feature-activations-graphql-integration-fields-etc/847) so we can activate it for you.
+
+## 1. Configure Previews
+
+In your repository, navigate to **Settings > Previews**. Here you can add the configuration for a new preview, just add:
+
+- **The Site Name**: The name of the current site your configuring.
+- **Domain URL**: You can add the URL of your live website or a localhost domain, such as: http://localhost:8000.
+- **Link Resolver (optional) **: In order to be taken directly to the page you are previewing instead of the homepage, add a Link Resolver which is an endpoint on your server that takes a Prismic document and returns the url for that document. More details on step _3. Add a Link Resolver endpoint._
+
+![](https://images.prismic.io/prismicio-docs-v3/YzI0MDU5ZGEtN2ZhMS00MjRjLWFjNzAtMzkzZTg3MmM5NGRl_7090417a-cf3f-457d-8229-2f8bbc7af4aa_screenshot2020-09-13at20.34.27.pngautocompressformatrect00954834w700h612?auto=compress,format&rect=0,0,700,612&w=960&h=839)
+
+## 2. Include the Prismic Toolbar javascript file
+
+You will need to include the Prismic toolbar script **on every page of your website including your 404 page.**
+
+You can find the correct script in your repository **Settings** section, under the **Previews** tab.
+
+**Settings > Previews > Script**
+
+```
+<script async defer src="https://static.cdn.prismic.io/prismic.js?new=true&repo=your-repo-name”></script>
+```
+
+> **Correct repo name**
+>
+> Note: This example script has your-repo-name at the end of the URL, this value needs to be replaced with your repository name. You can find the correct script for in your repository's **Settings > Previews > Script.**
+
+> **Shareable Previews & unpublished previews**
+>
+> To guarantee that Shearable Preview links and unpublished document previews work properly **you must ensure that these scripts are included on every page of your website, including your 404/Page Not Found page**. Otherwise these previews might not work.
+
+## 3. Add a Link Resolver endpoint
+
+In order to be taken directly to the page you are previewing instead of the homepage, you need to add a Link Resolver endpoint. A typical example of this would be:
+
+```bash
+https://{yoursite}/preview
+```
+
+In your preview settings add an endpoint to the optional Link Resolver field as explained in step 1.
+
+> **Using the official Prismic starter project?**
+>
+> If you are using [the official Prismic Laravel starter project](https://github.com/prismicio/php-laravel-starter), or any other of our starter projects, then you should already have all the code in place that you need for Previews and the Prismic Toolbar!<br/>
+> If you are not using this kit to make your queries, then follow the rest of the steps below.
+
+Now you need to add the Link Resolver endpoint in your website's router. When requested this endpoint must do the following:
+
+- Retrieve the preview token from the `token` parameter in the query string
+- Call the Prismic development kit with this token and the $linkResolver will retrieve the correct URL for the document being previewed
+- Redirect to the given URL
+
+> **The Preview Token**
+>
+> Note that the preview token will be a URL. You DO NOT need to follow this url. All you need to do is pass this token into the `previewSession` method then set the token as the value in your preview cookie as shown below.
+
+```
+<?php
+use Illuminate\Http\Request;
+
+Route::get('/preview', function (Request $request) use ($linkResolver) {
+    $token = $request->input('token');
+    $api = Api::get("https://your-repo-name.cdn.prismic.io/api/v2");
+    $url = $api->previewSession($token, $linkResolver, '/');
+    return response(null, 302)->header('Location', $url);
+});
+```
+
+The example above uses a Link Resolver function stored in the variable `$linkResolver` to determine the end url to redirect to. To learn more about how to set this up, check out our [Link Resolving](../04-beyond-the-api/01-link-resolving.md) page.
+
+## 4. Use the correct reference
+
+> **Are you using our php-kit?**
+>
+> This last step is only required if you are not using the [php-kit](https://github.com/prismicio/php-kit) to retrieve your API object.
+
+If you are using the `Api::get` method to retrieve your API object, then the correct reference will automatically be used and this last step is not necessary. If you **are not** using this method, then do the following:
+
+When you preview your website, a preview cookie is generated that contains the preview token. This token can be used as a valid ref to make Prismic API queries. For any query you make on your website, make sure to check for the Preview cookie and use this preview ref in the query options if the preview cookie exists.
+
+Here is how to retrieve the correct ref:
+
+```
+<?php
+use Prismic\Api;
+
+// Example ref selection for PHP - This is already done with the PHP kit
+function getPreviewRef() {
+    $cookieNames = [
+        str_replace(['.',' '], '_', Api::PREVIEW_COOKIE),
+        Api::PREVIEW_COOKIE,
+    ];
+    foreach ($cookieNames as $cookieName) {
+        if (isset($_COOKIE[$cookieName])) {
+            return $_COOKIE[$cookieName];
+        }
+    }
+    return null;
+}
+
+$previewRef = getPreviewRef();
+$ref = $previewRef ? $previewRef : $api->master()->getRef();
+```
+
+Then here is an example that shows how to use this ref in your query:
+
+```
+<?php
+$response = $api->query(
+    Predicates::at('document.type', 'blog_post'),
+    [ 'ref' => $ref ]
+);
+// $response contains the response object, $response->results holds the retrieved documents
+```
+
+And with that you should have everything in place that you need to begin previewing your content!
+
+## 5. Troubleshooting
+
+Mistakes happen. So sometimes you might to do a little troubleshooting to figure out where exactly the problem is from, [luckily we've created an article for just that](https://user-guides.prismic.io/en/articles/3403530-troubleshooting-previews).
+
+> **Deprecated: In-Website Edit Button**
+>
+> Note: The In-Website Edit Button has been deprecated in favor of the Preview Toolbar, which has an edit button built in.

--- a/docs/04-beyond-the-api/03-html-serializer.md
+++ b/docs/04-beyond-the-api/03-html-serializer.md
@@ -1,0 +1,159 @@
+# HTML Serializer
+
+You can customize the HTML output of a Rich Text Field by incorporating an HTML Serializer into your project. This allows you to do things like adding custom classes to certain elements or adding a target element to all hyperlinks.
+
+> **Before Reading**
+>
+> This page assumes that you have retrieved your content and stored it in a variable named `$document`.
+>
+> It is also assumed that you have set up a Link Resolver stored in the variable `$linkResolver`. When integrating a Link in your templates, a link resolver might be necessary as shown & discussed below. To learn more about this, check out our [Link Resolving](../04-beyond-the-api/01-link-resolving.md) page.
+
+## Adding the HTML Serializer function
+
+To be able to modify the HTML output of a Rich Text, you need to first create the HTML Serializer function.
+
+It will need to identify the element by type and return the desired output.
+
+> Make sure to add a default case that returns null. This will leave all the other elements untouched.
+
+Here is an example of an HTML Serializer that will prevent image elements from being wrapped in paragraph tags and add a custom class to all hyperlink and paragraph elements.
+
+```
+<?php
+$htmlSerializer = function ($element, $content) use ($linkResolver) {
+    switch ($element->type) {
+        // Add a class to paragraph elements
+        case 'paragraph':
+            return nl2br('<p class="paragraph-class">' . $content . '</p>');
+
+        // Don't wrap images in a <p> tag
+        case 'image':
+            return '<img src="' . $element->url . '" alt="' . htmlentities($element->alt) . '">';
+
+        // Add a class to hyperlinks
+        case 'hyperlink':
+            if ($element->data->link_type === 'Document') {
+                $linkUrl = $linkResolver ? $linkResolver($element->data) : '';
+            } else {
+                $linkUrl = $element->data->url;
+            }
+            if ($linkUrl === null) {
+                return $content;
+            }
+            $targetAttr = property_exists($element->data, 'target') ? ' target="' . $element->data->target . '" rel="noopener"' : null;
+            return '<a class="link-class" href="' . $linkUrl . '" ' . $targetAttr . '>' . $content . '</a>';
+
+        // Return null to stick with the default behavior for everything else
+        default:
+            return null;
+    }
+};
+```
+
+Note that if you want to change the output for the hyperlink element, you will need to use a Link Resolver. You can read more about this on the [Link Resolving](../04-beyond-the-api/01-link-resolving.md) page.
+
+## Using the serializer function
+
+To use it, all you need to do is pass the Serializer function into the `asHtml` method for a Rich Text element. Make sure to pass it in after the [Link Resolver](../04-beyond-the-api/01-link-resolving.md).
+
+```
+@php
+    use Prismic\Dom\RichText;
+@endphp
+
+<div>
+    {!! RichText::asHtml($document->data->rich_text, $linkResolver, $htmlSerializer) !!}
+</div>
+```
+
+## Example with all elements
+
+Here is an example that shows you how to change all of the available Rich Text elements.
+
+```
+<?php
+$htmlSerializer = function ($element, $content) use ($linkResolver) {
+    switch ($element->type) {
+        // Headings
+        case 'heading1':
+            return nl2br('<h1>' . $content . '</h1>');
+        case 'heading2':
+            return nl2br('<h2>' . $content . '</h2>');
+        case 'heading3':
+            return nl2br('<h3>' . $content . '</h3>');
+        case 'heading4':
+            return nl2br('<h4>' . $content . '</h4>');
+        case 'heading5':
+            return nl2br('<h5>' . $content . '</h5>');
+        case 'heading6':
+            return nl2br('<h6>' . $content . '</h6>');
+
+        // Paragraphs
+        case 'paragraph':
+            return nl2br('<p>' . $content . '</p>');
+
+        // List Items
+        case 'list-item':
+        case 'o-list-item':
+            return nl2br('<li>' . $content . '</li>');
+
+        // Images
+        case 'image':
+            return (
+                '<p class="block-img' . (property_exists($element, 'label') ? (' ' . $element->label) : '') . '">' .
+                    '<img src="' . $element->url . '" alt="' . htmlentities($element->alt) . '">' .
+                '</p>'
+            );
+
+        // Embeds
+        case 'embed':
+            $providerAttr = '';
+            if ($element->oembed->provider_name) {
+                $providerAttr = ' data-oembed-provider="' . strtolower($element->oembed->provider_name) . '"';
+            }
+            if ($element->oembed->html) {
+                return (
+                    '<div data-oembed="' . $element->oembed->embed_url . '" data-oembed-type="' . strtolower($element->oembed->type) . '"' . $providerAttr . '>' .
+                        $element->oembed->html .
+                    '</div>'
+                );
+            }
+            return '';
+
+        // Preformatted
+        case 'preformatted':
+            return '<pre>' . $content . '</pre>';
+
+        // Strong
+        case 'strong':
+            return '<strong>' . $content . '</strong>';
+
+        // Emphasis
+        case 'em':
+            return '<em>' . $content . '</em>';
+
+        // Hyperlinks
+        case 'hyperlink':
+            if ($element->data->link_type === 'Document') {
+                $linkUrl = $linkResolver ? $linkResolver($element->data) : '';
+            } else {
+                $linkUrl = $element->data->url;
+            }
+            if ($linkUrl === null) {
+                return $content;
+            }
+            $targetAttr = property_exists($element->data, 'target') ? ' target="' . $element->data->target . '" rel="noopener"' : null;
+            return '<a href="' . $linkUrl . '" ' . $targetAttr . '>' . $content . '</a>';
+
+        // Custom Spans
+        case 'label':
+            return '<span class="' . (property_exists($element->data, 'label') ? $element->data->label : '') . '">' . $content . '</span>';
+
+        // Default Case returns null
+        default:
+            return null;
+    }
+};
+```
+
+Note that if want to change the output for the hyperlink element, you will need to use a Link Resolver function. You can read more about this on the [Link Resolving](../04-beyond-the-api/01-link-resolving.md) page.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,12 @@
+# Prismic with Laravel
+
+Documentation for `prismic/php-laravel-starter` is organized into the following sections.
+
+-   [**Getting Started**](./01-getting-started)
+-   [**Query the API**](./02-query-the-api)
+-   [**Templating**](./03-templating)
+-   [**Beyond the API**](./04-beyond-the-api)
+
+To learn more about [Prismic](https://prismic.io), including documentation for other languages and frameworks, see the main Prismic Documentation site.
+
+[**Prismic Documentation**](https://prismic.io/docs)


### PR DESCRIPTION
This PR adds a local `docs` directory with PHP documentation from https://prismic.io/docs. The content from the website has been converted to Markdown so no content is lost.

Laravel documentation on https://prismic.io/docs will be removed. Documentation for this library should be updated as part of the repository.